### PR TITLE
feat: extract entropy-core crate (#744)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "entropy-core"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "receipt-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "packages/ifc-wasm",
     "packages/escalation-interface",
     "packages/afal-core",
+    "packages/entropy-core",
 ]
 
 [workspace.package]

--- a/data/test-vectors/entropy-status-v1.json
+++ b/data/test-vectors/entropy-status-v1.json
@@ -1,35 +1,8 @@
 {
-  "_comment": "Cross-language test vector for EntropyLedger / EntropyStatus. All hashes verified by Rust guardian-core. TypeScript must reproduce identical values.",
+  "_comment": "Cross-language test vector for EntropyLedger / EntropyStatus. All hashes verified by Rust entropy-core. TypeScript must reproduce identical values.",
   "description": "Three ledger entries. as_of = 2026-01-15T12:00:00Z. 7d window starts 2026-01-08T12:00:00Z. entry session-aaa (2026-01-08T10:00:00Z) falls outside 7d window by 2 hours.",
-  "input": {
-    "entries": [
-      {
-        "session_id": "session-aaa",
-        "pair_id": "pair-alice-bob",
-        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-        "entropy_millibits": 8000,
-        "timestamp": "2026-01-08T10:00:00Z",
-        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000001"
-      },
-      {
-        "session_id": "session-bbb",
-        "pair_id": "pair-alice-bob",
-        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-        "entropy_millibits": 12000,
-        "timestamp": "2026-01-14T20:00:00Z",
-        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000002"
-      },
-      {
-        "session_id": "session-ccc",
-        "pair_id": "pair-alice-carol",
-        "contract_key": "contract:none:v1",
-        "entropy_millibits": 5000,
-        "timestamp": "2026-01-15T09:00:00Z",
-        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000003"
-      }
-    ]
-  },
   "expected": {
+    "entropy_status_commitment": "bbcbcda532280f70e90b483ef2c5b65c36986dbe8de0ce48ff75c3bc5f6443aa",
     "entry_hashes": [
       "91a8474d68937e5a186c2fbade9cef4043d8cbc21326a8b12452f910fa3a1b65",
       "24cab32ecf1256df60f48dfa257272081e5e401fe510e6f74116833742b2b17b",
@@ -37,39 +10,66 @@
     ],
     "ledger_head_hash": "832eb48197b5074555399b62f4e5348c8b191084b032c7bdf044d2a1af2fd3a9",
     "status": {
-      "query": {
-        "pair_id": "pair-alice-bob",
-        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-        "session_entropy_millibits": 3000,
-        "as_of_utc": "2026-01-15T12:00:00Z"
-      },
-      "schema_version": "entropy_status_v1",
       "as_of_utc": "2026-01-15T12:00:00Z",
       "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-      "windows": {
-        "24h": {
-          "start_utc": "2026-01-14T12:00:00Z",
-          "end_utc": "2026-01-15T12:00:00Z"
-        },
-        "7d": {
-          "start_utc": "2026-01-08T12:00:00Z",
-          "end_utc": "2026-01-15T12:00:00Z"
-        }
+      "contract_totals_millibits": {
+        "7d": 12000
       },
-      "session_entropy_millibits": 3000,
       "counterparty_totals_millibits": {
         "24h": 12000,
         "7d": 12000,
         "lifetime": 20000
       },
-      "contract_totals_millibits": {
-        "7d": 12000
-      },
-      "session_count_counterparty": 2,
-      "ledger_head_hash": "832eb48197b5074555399b62f4e5348c8b191084b032c7bdf044d2a1af2fd3a9",
+      "delta_commitment_contract": "be066775e11350efb7ee229900a20d189453c44c031cd338bcb9bd3924147817",
       "delta_commitment_counterparty": "bfa3d1bb7738cfb77f7a8d89c443de9e51c6f5aad20df38e38effd10a8da60e8",
-      "delta_commitment_contract": "be066775e11350efb7ee229900a20d189453c44c031cd338bcb9bd3924147817"
-    },
-    "entropy_status_commitment": "bbcbcda532280f70e90b483ef2c5b65c36986dbe8de0ce48ff75c3bc5f6443aa"
+      "ledger_head_hash": "832eb48197b5074555399b62f4e5348c8b191084b032c7bdf044d2a1af2fd3a9",
+      "query": {
+        "as_of_utc": "2026-01-15T12:00:00Z",
+        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+        "pair_id": "pair-alice-bob",
+        "session_entropy_millibits": 3000
+      },
+      "schema_version": "entropy_status_v1",
+      "session_count_counterparty": 2,
+      "session_entropy_millibits": 3000,
+      "windows": {
+        "24h": {
+          "end_utc": "2026-01-15T12:00:00Z",
+          "start_utc": "2026-01-14T12:00:00Z"
+        },
+        "7d": {
+          "end_utc": "2026-01-15T12:00:00Z",
+          "start_utc": "2026-01-08T12:00:00Z"
+        }
+      }
+    }
+  },
+  "input": {
+    "entries": [
+      {
+        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+        "entropy_millibits": 8000,
+        "pair_id": "pair-alice-bob",
+        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000001",
+        "session_id": "session-aaa",
+        "timestamp": "2026-01-08T10:00:00Z"
+      },
+      {
+        "contract_key": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+        "entropy_millibits": 12000,
+        "pair_id": "pair-alice-bob",
+        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000002",
+        "session_id": "session-bbb",
+        "timestamp": "2026-01-14T20:00:00Z"
+      },
+      {
+        "contract_key": "contract:none:v1",
+        "entropy_millibits": 5000,
+        "pair_id": "pair-alice-carol",
+        "receipt_hash": "0000000000000000000000000000000000000000000000000000000000000003",
+        "session_id": "session-ccc",
+        "timestamp": "2026-01-15T09:00:00Z"
+      }
+    ]
   }
 }

--- a/packages/entropy-core/Cargo.toml
+++ b/packages/entropy-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "entropy-core"
+description = "Entropy ledger accounting and schema entropy measurement"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+receipt-core = { path = "../receipt-core" }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+
+[[bin]]
+name = "entropy-generate-vectors"
+path = "src/bin/generate_entropy_vectors.rs"

--- a/packages/entropy-core/src/bin/generate_entropy_vectors.rs
+++ b/packages/entropy-core/src/bin/generate_entropy_vectors.rs
@@ -1,0 +1,98 @@
+//! Generate entropy cross-language test vectors.
+//!
+//! Produces deterministic test vectors so TypeScript consumers can verify
+//! they produce identical hashes and commitments.
+
+use chrono::{TimeZone, Utc};
+use entropy_core::*;
+
+fn main() {
+    let vectors = generate_entropy_status_vectors();
+    let json = serde_json::to_string_pretty(&vectors).unwrap();
+    std::fs::write("data/test-vectors/entropy-status-v1.json", json + "\n").unwrap();
+
+    println!("Generated 1 test vector file in data/test-vectors/");
+}
+
+fn generate_entropy_status_vectors() -> serde_json::Value {
+    let now = Utc.with_ymd_and_hms(2026, 1, 15, 12, 0, 0).unwrap();
+
+    let entries = vec![
+        EntropyLedgerEntry {
+            session_id: "session-aaa".to_string(),
+            pair_id: "pair-alice-bob".to_string(),
+            contract_key: "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+                .to_string(),
+            entropy_millibits: 8000,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 8, 10, 0, 0).unwrap(),
+            receipt_hash: "0000000000000000000000000000000000000000000000000000000000000001"
+                .to_string(),
+        },
+        EntropyLedgerEntry {
+            session_id: "session-bbb".to_string(),
+            pair_id: "pair-alice-bob".to_string(),
+            contract_key: "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+                .to_string(),
+            entropy_millibits: 12000,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 14, 20, 0, 0).unwrap(),
+            receipt_hash: "0000000000000000000000000000000000000000000000000000000000000002"
+                .to_string(),
+        },
+        EntropyLedgerEntry {
+            session_id: "session-ccc".to_string(),
+            pair_id: "pair-alice-carol".to_string(),
+            contract_key: CONTRACT_KEY_NONE.to_string(),
+            entropy_millibits: 5000,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap(),
+            receipt_hash: "0000000000000000000000000000000000000000000000000000000000000003"
+                .to_string(),
+        },
+    ];
+
+    let entry_hashes: Vec<String> = entries.iter().map(|e| compute_entry_hash(e)).collect();
+    let ledger_head_hash = compute_ledger_head_hash(&entries);
+
+    let mut ledger = EntropyLedger::new();
+    for e in &entries {
+        ledger.append(e.clone()).unwrap();
+    }
+
+    let pair_id = "pair-alice-bob";
+    let contract_key = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+    let session_entropy_millibits = 3000u64;
+
+    let status = ledger.compute_status(pair_id, contract_key, session_entropy_millibits, now);
+    let entropy_status_commitment = compute_entropy_status_commitment(&status);
+
+    serde_json::json!({
+        "_comment": "Cross-language test vector for EntropyLedger / EntropyStatus. All hashes verified by Rust entropy-core. TypeScript must reproduce identical values.",
+        "description": "Three ledger entries. as_of = 2026-01-15T12:00:00Z. 7d window starts 2026-01-08T12:00:00Z. entry session-aaa (2026-01-08T10:00:00Z) falls outside 7d window by 2 hours.",
+        "input": {
+            "entries": serde_json::to_value(&entries).unwrap()
+        },
+        "expected": {
+            "entry_hashes": entry_hashes,
+            "ledger_head_hash": ledger_head_hash,
+            "status": {
+                "query": {
+                    "pair_id": pair_id,
+                    "contract_key": contract_key,
+                    "session_entropy_millibits": session_entropy_millibits,
+                    "as_of_utc": "2026-01-15T12:00:00Z"
+                },
+                "schema_version": status.schema_version,
+                "as_of_utc": "2026-01-15T12:00:00Z",
+                "contract_key": status.contract_key,
+                "windows": serde_json::to_value(&status.windows).unwrap(),
+                "session_entropy_millibits": status.session_entropy_millibits,
+                "counterparty_totals_millibits": serde_json::to_value(&status.counterparty_totals_millibits).unwrap(),
+                "contract_totals_millibits": serde_json::to_value(&status.contract_totals_millibits).unwrap(),
+                "session_count_counterparty": status.session_count_counterparty,
+                "ledger_head_hash": status.ledger_head_hash,
+                "delta_commitment_counterparty": status.delta_commitment_counterparty,
+                "delta_commitment_contract": status.delta_commitment_contract
+            },
+            "entropy_status_commitment": entropy_status_commitment
+        }
+    })
+}

--- a/packages/entropy-core/src/ledger.rs
+++ b/packages/entropy-core/src/ledger.rs
@@ -1,0 +1,937 @@
+//! Canonical entropy ledger wire format and commitment rules.
+//!
+//! This module defines the entropy ledger v1 format. Domain-separation
+//! prefixes (`vcav/entropy_ledger_entry_hash/v1`, etc.) are cryptographically
+//! frozen — the `vcav/` namespace is historical, not a policy claim.
+//! Any modification requires a version bump (v2 prefixes + new commitments).
+//!
+//! entropy-core provides accounting, not safety. Enforcement (STRICT mode,
+//! timing normalization, attestation) is the consuming runtime's responsibility.
+//!
+//! v1 is scalar: one entropy_millibits value per session. Per-label or
+//! per-compartment tracking (IFC extension) would require v2.
+//!
+//! ## Canonical ordering
+//!
+//! Entries are ordered by a strict total order: `(timestamp, session_id)`.
+//!
+//! 1. **Primary key:** `timestamp` (ascending `DateTime<Utc>`)
+//! 2. **Tie-breaker:** `session_id` (ascending lexicographic `String` comparison)
+//!
+//! No two entries may share the same `(timestamp, session_id)` pair.
+//! `append()` enforces this — out-of-order or duplicate entries are rejected.
+//!
+//! This ordering is **load-bearing**: entropy status commitments, ledger head
+//! hashes, and delta commitments all depend on entry order. A store that
+//! returns entries in a different order produces unverifiable receipts.
+
+use chrono::{DateTime, Utc};
+use receipt_core::canonicalize_serializable;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+// ============================================================================
+// Domain separation constants (frozen wire format)
+// ============================================================================
+
+const ENTRY_HASH_PREFIX: &str = "vcav/entropy_ledger_entry_hash/v1";
+const LEDGER_HEAD_SEED_PREFIX: &str = "vcav/ledger_head_seed/v1";
+const LEDGER_HEAD_STEP_PREFIX: &str = "vcav/ledger_head_step/v1";
+const DELTA_COUNTERPARTY_PREFIX: &str = "vcav/delta_commitment_counterparty/v1";
+const DELTA_CONTRACT_PREFIX: &str = "vcav/delta_commitment_contract/v1";
+const STATUS_COMMITMENT_PREFIX: &str = "vcav/entropy_status_hash/v1";
+
+// ============================================================================
+// Public constants
+// ============================================================================
+
+/// Sentinel for contractless sessions (domain-separated, cannot collide with hex hashes)
+pub const CONTRACT_KEY_NONE: &str = "contract:none:v1";
+pub const ENTROPY_STATUS_SCHEMA_VERSION: &str = "entropy_status_v1";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// A single entropy ledger entry, appended after each session receipt is signed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntropyLedgerEntry {
+    pub session_id: String,
+    pub pair_id: String,
+    pub contract_key: String,
+    pub entropy_millibits: u64,
+    pub timestamp: DateTime<Utc>,
+    pub receipt_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowBoundary {
+    pub start_utc: DateTime<Utc>,
+    pub end_utc: DateTime<Utc>,
+}
+
+/// Entropy Status Object (spec section 4.1)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntropyStatus {
+    pub schema_version: String,
+    pub as_of_utc: DateTime<Utc>,
+    pub contract_key: String,
+    pub windows: BTreeMap<String, WindowBoundary>,
+    pub session_entropy_millibits: u64,
+    pub counterparty_totals_millibits: BTreeMap<String, u64>,
+    pub contract_totals_millibits: BTreeMap<String, u64>,
+    pub session_count_counterparty: u64,
+    pub ledger_head_hash: String,
+    pub delta_commitment_counterparty: String,
+    pub delta_commitment_contract: String,
+}
+
+// ============================================================================
+// Error type
+// ============================================================================
+
+#[derive(Debug, thiserror::Error)]
+pub enum EntropyLedgerError {
+    #[error(
+        "entry violates canonical ordering: timestamp {new} precedes previous timestamp {prev}"
+    )]
+    TimestampRegression {
+        new: DateTime<Utc>,
+        prev: DateTime<Utc>,
+    },
+
+    #[error(
+        "entry violates canonical ordering: session_id {new:?} is not strictly after {prev:?} at equal timestamp {timestamp}"
+    )]
+    SessionIdNotStrictlyAfter {
+        new: String,
+        prev: String,
+        timestamp: DateTime<Utc>,
+    },
+}
+
+// ============================================================================
+// Hash helpers
+// ============================================================================
+
+fn sha256_hex(data: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn sha256_hex_prefixed(prefix: &str, data: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(data.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn sha256_hex_two(prefix: &str, a: &str, b: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(a.as_bytes());
+    hasher.update(b.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+// ============================================================================
+// Public free functions
+// ============================================================================
+
+/// Compute the entry hash for a ledger entry using domain-separated SHA-256.
+pub fn compute_entry_hash(entry: &EntropyLedgerEntry) -> String {
+    let canonical = canonicalize_serializable(entry)
+        .expect("EntropyLedgerEntry must be serializable");
+    sha256_hex_prefixed(ENTRY_HASH_PREFIX, &canonical)
+}
+
+/// Compute the rolling ledger head hash over all entries.
+///
+/// Algorithm:
+///   ledger_head_0 = SHA-256(LEDGER_HEAD_SEED_PREFIX)
+///   entry_hash_i  = SHA-256(ENTRY_HASH_PREFIX || RFC8785(entry_i))
+///   ledger_head_i = SHA-256(LEDGER_HEAD_STEP_PREFIX || ledger_head_{i-1} || entry_hash_i)
+pub fn compute_ledger_head_hash(entries: &[EntropyLedgerEntry]) -> String {
+    let mut head = sha256_hex(LEDGER_HEAD_SEED_PREFIX);
+    for entry in entries {
+        let entry_hash = compute_entry_hash(entry);
+        head = sha256_hex_two(LEDGER_HEAD_STEP_PREFIX, &head, &entry_hash);
+    }
+    head
+}
+
+/// Compute a delta commitment from a domain-separation prefix and a slice of entry hashes.
+///
+/// The hashes must be ordered by ascending (timestamp, session_id) before calling.
+pub fn compute_delta_commitment(prefix: &str, entry_hashes: &[String]) -> String {
+    let json_value = serde_json::to_value(entry_hashes)
+        .expect("Vec<String> must be serializable");
+    let canonical = receipt_core::canonicalize(&json_value);
+    sha256_hex_prefixed(prefix, &canonical)
+}
+
+/// Compute the entropy status commitment (hash of the status object itself).
+pub fn compute_entropy_status_commitment(status: &EntropyStatus) -> String {
+    let canonical = canonicalize_serializable(status)
+        .expect("EntropyStatus must be serializable");
+    sha256_hex_prefixed(STATUS_COMMITMENT_PREFIX, &canonical)
+}
+
+// ============================================================================
+// EntropyLedger
+// ============================================================================
+
+/// Append-only entropy ledger enforcing strict `(timestamp, session_id)` total order.
+#[derive(Debug, Clone, Default)]
+pub struct EntropyLedger {
+    entries: Vec<EntropyLedgerEntry>,
+}
+
+impl EntropyLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an entry, enforcing strict ascending `(timestamp, session_id)` order.
+    ///
+    /// Rejects entries where:
+    /// - `timestamp < prev.timestamp` (timestamp regression), or
+    /// - `timestamp == prev.timestamp && session_id <= prev.session_id` (tie-breaker violation)
+    pub fn append(&mut self, entry: EntropyLedgerEntry) -> Result<(), EntropyLedgerError> {
+        if let Some(last) = self.entries.last() {
+            if entry.timestamp < last.timestamp {
+                return Err(EntropyLedgerError::TimestampRegression {
+                    new: entry.timestamp,
+                    prev: last.timestamp,
+                });
+            }
+            if entry.timestamp == last.timestamp && entry.session_id <= last.session_id {
+                return Err(EntropyLedgerError::SessionIdNotStrictlyAfter {
+                    new: entry.session_id,
+                    prev: last.session_id.clone(),
+                    timestamp: entry.timestamp,
+                });
+            }
+        }
+        self.entries.push(entry);
+        Ok(())
+    }
+
+    /// Read access to all entries in canonical order.
+    pub fn entries(&self) -> &[EntropyLedgerEntry] {
+        &self.entries
+    }
+
+    /// Compute the full EntropyStatus for a given pair_id / contract_key / session.
+    pub fn compute_status(
+        &self,
+        pair_id: &str,
+        contract_key: &str,
+        session_entropy_millibits: u64,
+        now: DateTime<Utc>,
+    ) -> EntropyStatus {
+        // Window boundaries
+        let window_24h_start = now - chrono::Duration::hours(24);
+        let window_7d_start = now - chrono::Duration::days(7);
+
+        let mut windows = BTreeMap::new();
+        windows.insert(
+            "24h".to_string(),
+            WindowBoundary {
+                start_utc: window_24h_start,
+                end_utc: now,
+            },
+        );
+        windows.insert(
+            "7d".to_string(),
+            WindowBoundary {
+                start_utc: window_7d_start,
+                end_utc: now,
+            },
+        );
+
+        // Counterparty entries: pair_id matches
+        let counterparty_entries: Vec<&EntropyLedgerEntry> = self
+            .entries
+            .iter()
+            .filter(|e| e.pair_id == pair_id)
+            .collect();
+
+        // Aggregated counterparty totals
+        let counterparty_24h: u64 = counterparty_entries
+            .iter()
+            .filter(|e| e.timestamp >= window_24h_start)
+            .map(|e| e.entropy_millibits)
+            .sum();
+        let counterparty_7d: u64 = counterparty_entries
+            .iter()
+            .filter(|e| e.timestamp >= window_7d_start)
+            .map(|e| e.entropy_millibits)
+            .sum();
+        let counterparty_lifetime: u64 = counterparty_entries
+            .iter()
+            .map(|e| e.entropy_millibits)
+            .sum();
+
+        let mut counterparty_totals_millibits = BTreeMap::new();
+        counterparty_totals_millibits.insert("24h".to_string(), counterparty_24h);
+        counterparty_totals_millibits.insert("7d".to_string(), counterparty_7d);
+        counterparty_totals_millibits.insert("lifetime".to_string(), counterparty_lifetime);
+
+        // Contract entries: contract_key matches, within 7d window
+        let contract_7d: u64 = self
+            .entries
+            .iter()
+            .filter(|e| e.contract_key == contract_key && e.timestamp >= window_7d_start)
+            .map(|e| e.entropy_millibits)
+            .sum();
+
+        let mut contract_totals_millibits = BTreeMap::new();
+        contract_totals_millibits.insert("7d".to_string(), contract_7d);
+
+        // Session count for this counterparty (lifetime)
+        let session_count_counterparty = counterparty_entries.len() as u64;
+
+        // Ledger head hash over ALL entries
+        let ledger_head_hash = compute_ledger_head_hash(&self.entries);
+
+        // Delta commitment — counterparty slice (7d window), ordered by (timestamp, session_id)
+        let mut counterparty_7d_entries: Vec<&EntropyLedgerEntry> = counterparty_entries
+            .iter()
+            .copied()
+            .filter(|e| e.timestamp >= window_7d_start)
+            .collect();
+        counterparty_7d_entries
+            .sort_by(|a, b| a.timestamp.cmp(&b.timestamp).then(a.session_id.cmp(&b.session_id)));
+        let counterparty_hashes: Vec<String> = counterparty_7d_entries
+            .iter()
+            .map(|e| compute_entry_hash(e))
+            .collect();
+        let delta_commitment_counterparty =
+            compute_delta_commitment(DELTA_COUNTERPARTY_PREFIX, &counterparty_hashes);
+
+        // Delta commitment — contract slice (7d window), ordered by (timestamp, session_id)
+        let mut contract_7d_entries: Vec<&EntropyLedgerEntry> = self
+            .entries
+            .iter()
+            .filter(|e| e.contract_key == contract_key && e.timestamp >= window_7d_start)
+            .collect();
+        contract_7d_entries
+            .sort_by(|a, b| a.timestamp.cmp(&b.timestamp).then(a.session_id.cmp(&b.session_id)));
+        let contract_hashes: Vec<String> = contract_7d_entries
+            .iter()
+            .map(|e| compute_entry_hash(e))
+            .collect();
+        let delta_commitment_contract =
+            compute_delta_commitment(DELTA_CONTRACT_PREFIX, &contract_hashes);
+
+        EntropyStatus {
+            schema_version: ENTROPY_STATUS_SCHEMA_VERSION.to_string(),
+            as_of_utc: now,
+            contract_key: contract_key.to_string(),
+            windows,
+            session_entropy_millibits,
+            counterparty_totals_millibits,
+            contract_totals_millibits,
+            session_count_counterparty,
+            ledger_head_hash,
+            delta_commitment_counterparty,
+            delta_commitment_contract,
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn make_entry(
+        session_id: &str,
+        pair_id: &str,
+        contract_key: &str,
+        entropy_millibits: u64,
+        ts: DateTime<Utc>,
+    ) -> EntropyLedgerEntry {
+        EntropyLedgerEntry {
+            session_id: session_id.to_string(),
+            pair_id: pair_id.to_string(),
+            contract_key: contract_key.to_string(),
+            entropy_millibits,
+            timestamp: ts,
+            receipt_hash: format!("receipt-hash-{}", session_id),
+        }
+    }
+
+    fn ts(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).unwrap()
+    }
+
+    // ------------------------------------------------------------------
+    // Ordering tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_append_enforces_timestamp_ascending() {
+        let mut ledger = EntropyLedger::new();
+        ledger
+            .append(make_entry("s1", "p", CONTRACT_KEY_NONE, 100, ts(2025, 1, 1, 5)))
+            .unwrap();
+        // Earlier timestamp should be rejected
+        let result = ledger.append(make_entry(
+            "s2",
+            "p",
+            CONTRACT_KEY_NONE,
+            100,
+            ts(2025, 1, 1, 4),
+        ));
+        assert!(matches!(
+            result,
+            Err(EntropyLedgerError::TimestampRegression { .. })
+        ));
+    }
+
+    #[test]
+    fn test_append_enforces_session_id_tiebreaker() {
+        let mut ledger = EntropyLedger::new();
+        let t = ts(2025, 1, 1, 5);
+        ledger
+            .append(make_entry("s2", "p", CONTRACT_KEY_NONE, 100, t))
+            .unwrap();
+        // Same timestamp but lower session_id should be rejected
+        let result = ledger.append(make_entry("s1", "p", CONTRACT_KEY_NONE, 100, t));
+        assert!(matches!(
+            result,
+            Err(EntropyLedgerError::SessionIdNotStrictlyAfter { .. })
+        ));
+        // Same timestamp and same session_id should also be rejected
+        let result2 = ledger.append(make_entry("s2", "p", CONTRACT_KEY_NONE, 100, t));
+        assert!(matches!(
+            result2,
+            Err(EntropyLedgerError::SessionIdNotStrictlyAfter { .. })
+        ));
+        // Higher session_id at same timestamp is fine
+        ledger
+            .append(make_entry("s3", "p", CONTRACT_KEY_NONE, 100, t))
+            .unwrap();
+    }
+
+    /// Explicit negative ordering test: exercises every rejection path in a single
+    /// scenario to verify the total order `(timestamp, session_id)` is enforced.
+    #[test]
+    fn test_ordering_rejects_all_violations() {
+        let mut ledger = EntropyLedger::new();
+        let t1 = ts(2025, 6, 1, 10);
+        let t2 = ts(2025, 6, 1, 12);
+
+        // Seed with two entries: (t1, "beta"), (t2, "delta")
+        ledger
+            .append(make_entry("beta", "p", CONTRACT_KEY_NONE, 100, t1))
+            .unwrap();
+        ledger
+            .append(make_entry("delta", "p", CONTRACT_KEY_NONE, 100, t2))
+            .unwrap();
+
+        // 1. Timestamp regression: t1 < t2 (last entry)
+        let err = ledger
+            .append(make_entry("echo", "p", CONTRACT_KEY_NONE, 100, t1))
+            .unwrap_err();
+        assert!(
+            matches!(err, EntropyLedgerError::TimestampRegression { .. }),
+            "earlier timestamp must be rejected"
+        );
+
+        // 2. Equal timestamp, lower session_id: ("alpha" < "delta" at t2)
+        let err = ledger
+            .append(make_entry("alpha", "p", CONTRACT_KEY_NONE, 100, t2))
+            .unwrap_err();
+        assert!(
+            matches!(err, EntropyLedgerError::SessionIdNotStrictlyAfter { .. }),
+            "lower session_id at equal timestamp must be rejected"
+        );
+
+        // 3. Equal timestamp, equal session_id: ("delta" == "delta" at t2)
+        let err = ledger
+            .append(make_entry("delta", "p", CONTRACT_KEY_NONE, 100, t2))
+            .unwrap_err();
+        assert!(
+            matches!(err, EntropyLedgerError::SessionIdNotStrictlyAfter { .. }),
+            "duplicate (timestamp, session_id) must be rejected"
+        );
+
+        // 4. Valid append: equal timestamp, higher session_id succeeds
+        ledger
+            .append(make_entry("echo", "p", CONTRACT_KEY_NONE, 100, t2))
+            .unwrap();
+
+        // 5. Valid append: later timestamp always succeeds regardless of session_id
+        let t3 = ts(2025, 6, 1, 14);
+        ledger
+            .append(make_entry("alpha", "p", CONTRACT_KEY_NONE, 100, t3))
+            .unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Hash tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_ledger_head_hash() {
+        // Empty ledger: head = SHA-256(LEDGER_HEAD_SEED_PREFIX)
+        let expected = sha256_hex(LEDGER_HEAD_SEED_PREFIX);
+        assert_eq!(compute_ledger_head_hash(&[]), expected);
+        assert!(!expected.is_empty());
+    }
+
+    #[test]
+    fn test_single_entry_head_hash() {
+        let entry = make_entry("s1", "pair1", CONTRACT_KEY_NONE, 1000, ts(2025, 1, 1, 0));
+        let hash = compute_ledger_head_hash(&[entry.clone()]);
+
+        // Deterministic
+        assert_eq!(hash, compute_ledger_head_hash(&[entry]));
+        // Not the seed
+        assert_ne!(hash, sha256_hex(LEDGER_HEAD_SEED_PREFIX));
+    }
+
+    #[test]
+    fn test_multiple_entries_head_hash() {
+        let e1 = make_entry("s1", "pair1", CONTRACT_KEY_NONE, 1000, ts(2025, 1, 1, 0));
+        let e2 = make_entry("s2", "pair1", CONTRACT_KEY_NONE, 2000, ts(2025, 1, 1, 1));
+        let e3 = make_entry("s3", "pair2", "abc123", 500, ts(2025, 1, 1, 2));
+
+        // Hand-compute rolling hash
+        let seed = sha256_hex(LEDGER_HEAD_SEED_PREFIX);
+        let h1 = compute_entry_hash(&e1);
+        let h2 = compute_entry_hash(&e2);
+        let h3 = compute_entry_hash(&e3);
+
+        let head1 = sha256_hex_two(LEDGER_HEAD_STEP_PREFIX, &seed, &h1);
+        let head2 = sha256_hex_two(LEDGER_HEAD_STEP_PREFIX, &head1, &h2);
+        let head3 = sha256_hex_two(LEDGER_HEAD_STEP_PREFIX, &head2, &h3);
+
+        assert_eq!(compute_ledger_head_hash(&[e1, e2, e3]), head3);
+    }
+
+    #[test]
+    fn test_head_hash_determinism() {
+        let e1 = make_entry("s1", "pair1", CONTRACT_KEY_NONE, 1000, ts(2025, 1, 1, 0));
+        let e2 = make_entry("s2", "pair1", CONTRACT_KEY_NONE, 2000, ts(2025, 1, 1, 1));
+        let entries = vec![e1, e2];
+
+        let h1 = compute_ledger_head_hash(&entries);
+        let h2 = compute_ledger_head_hash(&entries);
+        let h3 = compute_ledger_head_hash(&entries);
+        assert_eq!(h1, h2);
+        assert_eq!(h2, h3);
+    }
+
+    // ------------------------------------------------------------------
+    // Aggregation tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_aggregation_24h() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        // Append in monotonic order: older first (25h ago), newer second (12h ago)
+        ledger
+            .append(make_entry(
+                "s2",
+                "pair1",
+                CONTRACT_KEY_NONE,
+                500,
+                now - chrono::Duration::hours(25),
+            ))
+            .unwrap();
+        ledger
+            .append(make_entry(
+                "s1",
+                "pair1",
+                CONTRACT_KEY_NONE,
+                1000,
+                now - chrono::Duration::hours(12),
+            ))
+            .unwrap();
+
+        let status = ledger.compute_status("pair1", CONTRACT_KEY_NONE, 0, now);
+        // Only s1 (12h ago) is within 24h window
+        assert_eq!(status.counterparty_totals_millibits["24h"], 1000);
+        // Both entries are within 7d
+        assert_eq!(status.counterparty_totals_millibits["7d"], 1500);
+        assert_eq!(status.counterparty_totals_millibits["lifetime"], 1500);
+    }
+
+    #[test]
+    fn test_aggregation_7d() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        // Append in monotonic order: older first (8d ago), newer second (3d ago)
+        ledger
+            .append(make_entry(
+                "s2",
+                "p",
+                CONTRACT_KEY_NONE,
+                100,
+                now - chrono::Duration::days(8),
+            ))
+            .unwrap();
+        ledger
+            .append(make_entry(
+                "s1",
+                "p",
+                CONTRACT_KEY_NONE,
+                300,
+                now - chrono::Duration::days(3),
+            ))
+            .unwrap();
+
+        let status = ledger.compute_status("p", CONTRACT_KEY_NONE, 0, now);
+        // Only s1 (3d ago) is within 7d window
+        assert_eq!(status.counterparty_totals_millibits["7d"], 300);
+        // Both in lifetime
+        assert_eq!(status.counterparty_totals_millibits["lifetime"], 400);
+    }
+
+    #[test]
+    fn test_aggregation_lifetime() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        for i in 0u64..5 {
+            ledger
+                .append(make_entry(
+                    &format!("s{}", i),
+                    "pair1",
+                    CONTRACT_KEY_NONE,
+                    1000,
+                    now - chrono::Duration::days(100 - i as i64),
+                ))
+                .unwrap();
+        }
+        let status = ledger.compute_status("pair1", CONTRACT_KEY_NONE, 0, now);
+        assert_eq!(status.counterparty_totals_millibits["lifetime"], 5000);
+    }
+
+    #[test]
+    fn test_multi_contract_aggregation() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        ledger
+            .append(make_entry(
+                "s1",
+                "p",
+                "contract_a",
+                1000,
+                now - chrono::Duration::days(1),
+            ))
+            .unwrap();
+        ledger
+            .append(make_entry(
+                "s2",
+                "p",
+                "contract_b",
+                500,
+                now - chrono::Duration::days(1),
+            ))
+            .unwrap();
+        ledger
+            .append(make_entry(
+                "s3",
+                "p",
+                "contract_a",
+                200,
+                now - chrono::Duration::hours(1),
+            ))
+            .unwrap();
+
+        let status_a = ledger.compute_status("p", "contract_a", 0, now);
+        assert_eq!(status_a.contract_totals_millibits["7d"], 1200);
+
+        let status_b = ledger.compute_status("p", "contract_b", 0, now);
+        assert_eq!(status_b.contract_totals_millibits["7d"], 500);
+    }
+
+    #[test]
+    fn test_contract_none_sentinel() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        ledger
+            .append(make_entry(
+                "s1",
+                "pair1",
+                CONTRACT_KEY_NONE,
+                999,
+                now - chrono::Duration::hours(1),
+            ))
+            .unwrap();
+        let status = ledger.compute_status("pair1", CONTRACT_KEY_NONE, 0, now);
+        assert_eq!(status.contract_key, CONTRACT_KEY_NONE);
+        assert_eq!(status.contract_totals_millibits["7d"], 999);
+    }
+
+    // ------------------------------------------------------------------
+    // Delta commitment tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_delta_commitment_counterparty() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        let e1 = make_entry(
+            "s1",
+            "pair1",
+            CONTRACT_KEY_NONE,
+            100,
+            now - chrono::Duration::days(1),
+        );
+        let e2 = make_entry(
+            "s2",
+            "pair1",
+            CONTRACT_KEY_NONE,
+            200,
+            now - chrono::Duration::hours(6),
+        );
+        // Different pair — should NOT appear in counterparty delta
+        let e3 = make_entry(
+            "s3",
+            "pair2",
+            CONTRACT_KEY_NONE,
+            300,
+            now - chrono::Duration::hours(3),
+        );
+
+        ledger.append(e1.clone()).unwrap();
+        ledger.append(e2.clone()).unwrap();
+        ledger.append(e3).unwrap();
+
+        let status = ledger.compute_status("pair1", CONTRACT_KEY_NONE, 0, now);
+
+        // Compute expected delta manually
+        let expected_hashes = vec![compute_entry_hash(&e1), compute_entry_hash(&e2)];
+        let expected = compute_delta_commitment(DELTA_COUNTERPARTY_PREFIX, &expected_hashes);
+        assert_eq!(status.delta_commitment_counterparty, expected);
+    }
+
+    #[test]
+    fn test_delta_commitment_contract() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        let e1 = make_entry("s1", "pair1", "contract_x", 100, now - chrono::Duration::days(1));
+        let e2 = make_entry(
+            "s2",
+            "pair2",
+            "contract_x",
+            200,
+            now - chrono::Duration::hours(6),
+        );
+        let e3 = make_entry(
+            "s3",
+            "pair1",
+            "contract_y",
+            300,
+            now - chrono::Duration::hours(3),
+        );
+
+        ledger.append(e1.clone()).unwrap();
+        ledger.append(e2.clone()).unwrap();
+        ledger.append(e3).unwrap();
+
+        let status = ledger.compute_status("pair1", "contract_x", 0, now);
+
+        // Only e1 and e2 match contract_x
+        let expected_hashes = vec![compute_entry_hash(&e1), compute_entry_hash(&e2)];
+        let expected = compute_delta_commitment(DELTA_CONTRACT_PREFIX, &expected_hashes);
+        assert_eq!(status.delta_commitment_contract, expected);
+    }
+
+    #[test]
+    fn test_entropy_status_commitment() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+        ledger
+            .append(make_entry(
+                "s1",
+                "pair1",
+                CONTRACT_KEY_NONE,
+                500,
+                now - chrono::Duration::hours(2),
+            ))
+            .unwrap();
+        let status = ledger.compute_status("pair1", CONTRACT_KEY_NONE, 500, now);
+
+        let c1 = compute_entropy_status_commitment(&status);
+        let c2 = compute_entropy_status_commitment(&status);
+        assert_eq!(c1, c2);
+        assert!(!c1.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // Cross-language fixture test
+    // ------------------------------------------------------------------
+
+    /// Verifies against the cross-language fixture file data/test-vectors/entropy-status-v1.json.
+    /// If this test fails, the fixture is out of sync with the Rust implementation.
+    #[test]
+    fn test_cross_language_fixture() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 15, 12, 0, 0).unwrap();
+
+        let entries = vec![
+            EntropyLedgerEntry {
+                session_id: "session-aaa".to_string(),
+                pair_id: "pair-alice-bob".to_string(),
+                contract_key:
+                    "abc123def456abc123def456abc123def456abc123def456abc123def456abc1".to_string(),
+                entropy_millibits: 8000,
+                timestamp: Utc.with_ymd_and_hms(2026, 1, 8, 10, 0, 0).unwrap(),
+                receipt_hash:
+                    "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
+            },
+            EntropyLedgerEntry {
+                session_id: "session-bbb".to_string(),
+                pair_id: "pair-alice-bob".to_string(),
+                contract_key:
+                    "abc123def456abc123def456abc123def456abc123def456abc123def456abc1".to_string(),
+                entropy_millibits: 12000,
+                timestamp: Utc.with_ymd_and_hms(2026, 1, 14, 20, 0, 0).unwrap(),
+                receipt_hash:
+                    "0000000000000000000000000000000000000000000000000000000000000002".to_string(),
+            },
+            EntropyLedgerEntry {
+                session_id: "session-ccc".to_string(),
+                pair_id: "pair-alice-carol".to_string(),
+                contract_key: CONTRACT_KEY_NONE.to_string(),
+                entropy_millibits: 5000,
+                timestamp: Utc.with_ymd_and_hms(2026, 1, 15, 9, 0, 0).unwrap(),
+                receipt_hash:
+                    "0000000000000000000000000000000000000000000000000000000000000003".to_string(),
+            },
+        ];
+
+        // Verify entry hashes
+        assert_eq!(
+            compute_entry_hash(&entries[0]),
+            "91a8474d68937e5a186c2fbade9cef4043d8cbc21326a8b12452f910fa3a1b65"
+        );
+        assert_eq!(
+            compute_entry_hash(&entries[1]),
+            "24cab32ecf1256df60f48dfa257272081e5e401fe510e6f74116833742b2b17b"
+        );
+        assert_eq!(
+            compute_entry_hash(&entries[2]),
+            "3f5968dd7d2dd44bfff920cfbaf439870dc41de38594b49588fa4510a67058f7"
+        );
+
+        // Verify ledger head hash
+        assert_eq!(
+            compute_ledger_head_hash(&entries),
+            "832eb48197b5074555399b62f4e5348c8b191084b032c7bdf044d2a1af2fd3a9"
+        );
+
+        // Verify compute_status
+        let mut ledger = EntropyLedger::new();
+        for e in &entries {
+            ledger.append(e.clone()).unwrap();
+        }
+        let status = ledger.compute_status(
+            "pair-alice-bob",
+            "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+            3000,
+            now,
+        );
+
+        // Window aggregations
+        assert_eq!(status.counterparty_totals_millibits["24h"], 12000);
+        assert_eq!(status.counterparty_totals_millibits["7d"], 12000);
+        assert_eq!(status.counterparty_totals_millibits["lifetime"], 20000);
+        assert_eq!(status.contract_totals_millibits["7d"], 12000);
+        assert_eq!(status.session_count_counterparty, 2);
+
+        // Commitments
+        assert_eq!(
+            status.delta_commitment_counterparty,
+            "bfa3d1bb7738cfb77f7a8d89c443de9e51c6f5aad20df38e38effd10a8da60e8"
+        );
+        assert_eq!(
+            status.delta_commitment_contract,
+            "be066775e11350efb7ee229900a20d189453c44c031cd338bcb9bd3924147817"
+        );
+        assert_eq!(
+            compute_entropy_status_commitment(&status),
+            "bbcbcda532280f70e90b483ef2c5b65c36986dbe8de0ce48ff75c3bc5f6443aa"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Full status test
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_compute_status_full() {
+        let mut ledger = EntropyLedger::new();
+        let now = ts(2025, 6, 10, 12);
+
+        let e1 = make_entry("s1", "pair1", "ckey1", 1000, now - chrono::Duration::days(6));
+        let e2 = make_entry("s2", "pair1", "ckey1", 2000, now - chrono::Duration::hours(20));
+        let e3 = make_entry("s3", "pair2", "ckey1", 500, now - chrono::Duration::hours(10));
+
+        ledger.append(e1.clone()).unwrap();
+        ledger.append(e2.clone()).unwrap();
+        ledger.append(e3.clone()).unwrap();
+
+        let session_entropy = 777u64;
+        let status = ledger.compute_status("pair1", "ckey1", session_entropy, now);
+
+        // Schema version
+        assert_eq!(status.schema_version, ENTROPY_STATUS_SCHEMA_VERSION);
+
+        // as_of_utc
+        assert_eq!(status.as_of_utc, now);
+
+        // contract_key
+        assert_eq!(status.contract_key, "ckey1");
+
+        // Windows present
+        assert!(status.windows.contains_key("24h"));
+        assert!(status.windows.contains_key("7d"));
+
+        // 24h window boundaries
+        let w24 = &status.windows["24h"];
+        assert_eq!(w24.start_utc, now - chrono::Duration::hours(24));
+        assert_eq!(w24.end_utc, now);
+
+        // 7d window boundaries
+        let w7d = &status.windows["7d"];
+        assert_eq!(w7d.start_utc, now - chrono::Duration::days(7));
+        assert_eq!(w7d.end_utc, now);
+
+        // session_entropy_millibits passthrough
+        assert_eq!(status.session_entropy_millibits, session_entropy);
+
+        // Counterparty totals (pair1 only)
+        assert_eq!(status.counterparty_totals_millibits["24h"], 2000); // e2 only
+        assert_eq!(status.counterparty_totals_millibits["7d"], 3000); // e1 + e2
+        assert_eq!(status.counterparty_totals_millibits["lifetime"], 3000);
+
+        // Contract totals (ckey1, 7d)
+        assert_eq!(status.contract_totals_millibits["7d"], 3500); // e1+e2+e3
+
+        // Session count for pair1
+        assert_eq!(status.session_count_counterparty, 2);
+
+        // Head hash matches full ledger
+        assert_eq!(
+            status.ledger_head_hash,
+            compute_ledger_head_hash(&[e1, e2, e3])
+        );
+
+        // Delta commitments are non-empty hex strings
+        assert_eq!(status.delta_commitment_counterparty.len(), 64);
+        assert_eq!(status.delta_commitment_contract.len(), 64);
+    }
+}

--- a/packages/entropy-core/src/lib.rs
+++ b/packages/entropy-core/src/lib.rs
@@ -1,0 +1,55 @@
+#![forbid(unsafe_code)]
+//! # entropy-core
+//!
+//! Entropy ledger accounting and schema entropy measurement.
+//!
+//! This crate measures and tracks information release. It does **not** enforce
+//! limits, normalize timing, or bind to hardware attestation. Enforcement is
+//! the responsibility of the consuming runtime (e.g. guardian-core for VCAV,
+//! relay for AgentVault).
+//!
+//! ## Design principles
+//!
+//! - **Accounting, not safety**: Provides measurement primitives and an
+//!   append-only ledger. Policy decisions belong in consumers.
+//! - **Vault-agnostic**: No VCAV-specific logic, allowlists, or defaults.
+//! - **Cross-language contract**: JSON test vectors in sibling directories
+//!   define the wire format; this crate is the Rust implementation.
+//! - **Frozen wire format**: Domain prefixes are cryptographic constants.
+//!   The `vcav/` namespace is historical — changing it breaks commitments.
+//!
+//! ## v1 scope
+//!
+//! v1 tracks entropy as a single scalar (`u64` millibits) per session.
+//! Per-label or per-compartment tracking (IFC extension) would require a v2
+//! schema with new domain prefixes and status commitments.
+
+pub mod ledger;
+pub mod measurement;
+pub mod store;
+
+// ---------------------------------------------------------------------------
+// Re-exports: ledger
+// ---------------------------------------------------------------------------
+
+pub use ledger::{
+    compute_delta_commitment, compute_entry_hash, compute_entropy_status_commitment,
+    compute_ledger_head_hash, EntropyLedger, EntropyLedgerEntry, EntropyLedgerError,
+    EntropyStatus, WindowBoundary, CONTRACT_KEY_NONE, ENTROPY_STATUS_SCHEMA_VERSION,
+};
+
+// ---------------------------------------------------------------------------
+// Re-exports: measurement
+// ---------------------------------------------------------------------------
+
+pub use measurement::{
+    calculate_schema_entropy, calculate_schema_entropy_upper_bound,
+    ensure_schema_entropy_within_ceiling, enum_entropy_bits, EntropyError,
+    ENTROPY_UPPER_BOUND_KEY,
+};
+
+// ---------------------------------------------------------------------------
+// Re-exports: store
+// ---------------------------------------------------------------------------
+
+pub use store::{EntropyLedgerStore, InMemoryEntropyLedgerStore};

--- a/packages/entropy-core/src/measurement.rs
+++ b/packages/entropy-core/src/measurement.rs
@@ -1,0 +1,535 @@
+//! Schema entropy measurement.
+//!
+//! Calculates information-theoretic entropy of schema-constrained outputs based
+//! on enum cardinalities and schema structure. Provides generic measurement
+//! primitives — policy decisions (per-purpose limits, schema allowlists) belong
+//! in the consuming runtime.
+//!
+//! All vault outputs must be enum-only, constant-shape. This module calculates
+//! the information-theoretic entropy of such outputs.
+
+use serde_json::Value;
+use thiserror::Error;
+
+/// Errors that can occur during entropy measurement.
+///
+/// All variants are policy-neutral — they describe schema structure problems,
+/// not runtime policy violations.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum EntropyError {
+    #[error("schema root must be an object type")]
+    NotAnObject,
+
+    #[error("field '{field}' is not a string enum (only string enum fields supported)")]
+    NonEnumField { field: String },
+
+    #[error("field '{field}' has empty enum")]
+    EmptyEnum { field: String },
+
+    #[error("schema node uses unsupported construct at '{path}'")]
+    UnsupportedSchemaConstruct { path: String },
+
+    #[error("unresolvable local $ref '{reference}' at '{path}'")]
+    UnresolvableLocalRef { path: String, reference: String },
+
+    #[error("schema node at '{path}' requires {key} metadata")]
+    MissingUpperBoundMetadata { path: String, key: String },
+
+    #[error("entropy calculation overflow at '{path}'")]
+    EntropyOverflow { path: String },
+
+    #[error("schema entropy upper bound ({upper}) exceeds ceiling ({ceiling})")]
+    EntropyCeilingExceeded { upper: u16, ceiling: u16 },
+}
+
+/// Custom schema metadata key for conservative upper bounds when exact enumeration is unsupported.
+pub const ENTROPY_UPPER_BOUND_KEY: &str = "x-vcav-entropy-bits-upper-bound";
+
+/// Calculate entropy in bits for an enum with given cardinality.
+///
+/// Formula: `ceil(log2(cardinality))`. Returns 0 for cardinality <= 1.
+pub fn enum_entropy_bits(cardinality: usize) -> u16 {
+    if cardinality <= 1 {
+        return 0;
+    }
+    (cardinality as f64).log2().ceil() as u16
+}
+
+/// Calculate a conservative entropy upper bound for a JSON Schema.
+///
+/// Supports exact enumeration for object + enum schemas including local `#/$defs/*` refs.
+/// For unsupported constructs, requires `x-vcav-entropy-bits-upper-bound` at the node.
+pub fn calculate_schema_entropy_upper_bound(schema: &Value) -> Result<u16, EntropyError> {
+    calculate_upper_bound_at(schema, schema, "$")
+}
+
+/// Validate computed schema upper bound against a configured entropy ceiling.
+pub fn ensure_schema_entropy_within_ceiling(
+    schema: &Value,
+    ceiling: u16,
+) -> Result<u16, EntropyError> {
+    let upper = calculate_schema_entropy_upper_bound(schema)?;
+    if upper > ceiling {
+        return Err(EntropyError::EntropyCeilingExceeded { upper, ceiling });
+    }
+    Ok(upper)
+}
+
+fn calculate_upper_bound_at(root: &Value, node: &Value, path: &str) -> Result<u16, EntropyError> {
+    if let Some(bits) = explicit_upper_bound(node, path)? {
+        return Ok(bits);
+    }
+
+    if let Some(reference) = node.get("$ref").and_then(Value::as_str) {
+        let target = resolve_local_ref(root, reference).ok_or_else(|| {
+            EntropyError::UnresolvableLocalRef {
+                path: format!("{path}/$ref"),
+                reference: reference.to_string(),
+            }
+        })?;
+        return calculate_upper_bound_at(root, target, reference);
+    }
+
+    if node.get("const").is_some() {
+        return Ok(0);
+    }
+
+    if has_unsupported_composition(node) {
+        return Err(EntropyError::MissingUpperBoundMetadata {
+            path: path.to_string(),
+            key: ENTROPY_UPPER_BOUND_KEY.to_string(),
+        });
+    }
+
+    if let Some(enum_values) = node.get("enum").and_then(Value::as_array) {
+        if enum_values.is_empty() {
+            return Err(EntropyError::EmptyEnum {
+                field: path.to_string(),
+            });
+        }
+        if !enum_values.iter().all(Value::is_string) {
+            return Err(EntropyError::UnsupportedSchemaConstruct {
+                path: path.to_string(),
+            });
+        }
+        return Ok(enum_entropy_bits(enum_values.len()));
+    }
+
+    if node.get("type").and_then(Value::as_str) == Some("object") {
+        let properties = match node.get("properties") {
+            Some(Value::Object(props)) => props,
+            _ => return Ok(0),
+        };
+        let mut total_bits: u16 = 0;
+        for (field, field_schema) in properties {
+            let child_path = format!("{path}/properties/{field}");
+            let bits = calculate_upper_bound_at(root, field_schema, &child_path)?;
+            total_bits =
+                total_bits
+                    .checked_add(bits)
+                    .ok_or_else(|| EntropyError::EntropyOverflow {
+                        path: child_path.clone(),
+                    })?;
+        }
+        return Ok(total_bits);
+    }
+
+    Err(EntropyError::MissingUpperBoundMetadata {
+        path: path.to_string(),
+        key: ENTROPY_UPPER_BOUND_KEY.to_string(),
+    })
+}
+
+fn explicit_upper_bound(node: &Value, path: &str) -> Result<Option<u16>, EntropyError> {
+    let Some(raw) = node.get(ENTROPY_UPPER_BOUND_KEY) else {
+        return Ok(None);
+    };
+    let value = raw
+        .as_u64()
+        .ok_or_else(|| EntropyError::UnsupportedSchemaConstruct {
+            path: format!("{path}/{ENTROPY_UPPER_BOUND_KEY}"),
+        })?;
+    Ok(Some(value.min(u16::MAX as u64) as u16))
+}
+
+fn has_unsupported_composition(node: &Value) -> bool {
+    ["oneOf", "anyOf", "allOf", "not"]
+        .iter()
+        .any(|key| node.get(*key).is_some())
+}
+
+fn resolve_local_ref<'a>(root: &'a Value, reference: &str) -> Option<&'a Value> {
+    if !reference.starts_with("#/") {
+        return None;
+    }
+    let mut current = root;
+    for token in reference.trim_start_matches("#/").split('/') {
+        let key = token.replace("~1", "/").replace("~0", "~");
+        current = current.get(&key)?;
+    }
+    Some(current)
+}
+
+/// Calculate total entropy bits from a JSON Schema.
+///
+/// The schema must be an object type where all properties are string enums.
+/// Returns the sum of entropy bits for all enum fields.
+///
+/// # Errors
+/// - `EntropyError::NotAnObject` if schema is not an object type
+/// - `EntropyError::NonEnumField` if any field is not a string enum
+/// - `EntropyError::EmptyEnum` if any enum has no values
+pub fn calculate_schema_entropy(schema: &Value) -> Result<u16, EntropyError> {
+    // Explicit matching for auditability - no catch-all
+    // Schema must be an object type
+    let schema_type = schema.get("type").and_then(|t| t.as_str());
+    if schema_type != Some("object") {
+        return Err(EntropyError::NotAnObject);
+    }
+
+    // Get properties
+    let properties = match schema.get("properties") {
+        Some(Value::Object(props)) => props,
+        _ => return Ok(0), // No properties = 0 entropy
+    };
+
+    let mut total_bits: u16 = 0;
+
+    for (field_name, field_schema) in properties {
+        // Each field must be a string type
+        let field_type = field_schema.get("type").and_then(|t| t.as_str());
+        if field_type != Some("string") {
+            return Err(EntropyError::NonEnumField {
+                field: field_name.clone(),
+            });
+        }
+
+        // Must have enum array
+        let enum_values = match field_schema.get("enum") {
+            Some(Value::Array(arr)) => arr,
+            _ => {
+                return Err(EntropyError::NonEnumField {
+                    field: field_name.clone(),
+                });
+            }
+        };
+
+        if enum_values.is_empty() {
+            return Err(EntropyError::EmptyEnum {
+                field: field_name.clone(),
+            });
+        }
+
+        let cardinality = enum_values.len();
+        total_bits = total_bits
+            .checked_add(enum_entropy_bits(cardinality))
+            .ok_or_else(|| EntropyError::EntropyOverflow {
+                path: format!("$.properties/{field_name}"),
+            })?;
+    }
+
+    Ok(total_bits)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ==================== enum_entropy_bits tests ====================
+
+    #[test]
+    fn test_enum_entropy_edge_cases() {
+        assert_eq!(enum_entropy_bits(0), 0);
+        assert_eq!(enum_entropy_bits(1), 0);
+    }
+
+    #[test]
+    fn test_enum_entropy_powers_of_two() {
+        assert_eq!(enum_entropy_bits(2), 1);
+        assert_eq!(enum_entropy_bits(4), 2);
+        assert_eq!(enum_entropy_bits(8), 3);
+        assert_eq!(enum_entropy_bits(16), 4);
+        assert_eq!(enum_entropy_bits(256), 8);
+    }
+
+    #[test]
+    fn test_enum_entropy_non_powers() {
+        assert_eq!(enum_entropy_bits(3), 2);
+        assert_eq!(enum_entropy_bits(5), 3);
+        assert_eq!(enum_entropy_bits(9), 4);
+        assert_eq!(enum_entropy_bits(17), 5);
+    }
+
+    // ==================== calculate_schema_entropy tests ====================
+
+    #[test]
+    fn test_calculate_schema_entropy_simple() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string",
+                    "enum": ["YES", "NO"]
+                }
+            }
+        });
+        assert_eq!(calculate_schema_entropy(&schema).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_multiple_fields() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string",
+                    "enum": ["PROCEED", "DO_NOT_PROCEED", "INCONCLUSIVE"]
+                },
+                "confidence": {
+                    "type": "string",
+                    "enum": ["LOW", "MEDIUM", "HIGH"]
+                }
+            }
+        });
+        assert_eq!(calculate_schema_entropy(&schema).unwrap(), 4);
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_compatibility_schema() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string",
+                    "enum": ["PROCEED", "DO_NOT_PROCEED", "INCONCLUSIVE"]
+                },
+                "confidence_bucket": {
+                    "type": "string",
+                    "enum": ["LOW", "MEDIUM", "HIGH"]
+                },
+                "reason_code": {
+                    "type": "string",
+                    "enum": [
+                        "GOALS_MISMATCH", "COMMUNICATION_STYLE", "LOGISTICS",
+                        "MUTUAL_INTEREST_UNCLEAR", "RESERVED_01", "RESERVED_02",
+                        "RESERVED_03", "RESERVED_04", "RESERVED_05", "RESERVED_06",
+                        "RESERVED_07", "RESERVED_08", "UNKNOWN"
+                    ]
+                }
+            }
+        });
+        // 2 + 2 + 4 = 8 bits
+        assert_eq!(calculate_schema_entropy(&schema).unwrap(), 8);
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_no_properties() {
+        let schema = json!({ "type": "object" });
+        assert_eq!(calculate_schema_entropy(&schema).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_not_object() {
+        let schema = json!({ "type": "string" });
+        assert_eq!(
+            calculate_schema_entropy(&schema),
+            Err(EntropyError::NotAnObject)
+        );
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_non_string_field() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer" }
+            }
+        });
+        assert_eq!(
+            calculate_schema_entropy(&schema),
+            Err(EntropyError::NonEnumField {
+                field: "count".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_string_without_enum() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            }
+        });
+        assert_eq!(
+            calculate_schema_entropy(&schema),
+            Err(EntropyError::NonEnumField {
+                field: "name".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_empty_enum() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": []
+                }
+            }
+        });
+        assert_eq!(
+            calculate_schema_entropy(&schema),
+            Err(EntropyError::EmptyEnum {
+                field: "status".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_calculate_schema_entropy_single_value_enum() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["ONLY_ONE"]
+                }
+            }
+        });
+        assert_eq!(calculate_schema_entropy(&schema).unwrap(), 0);
+    }
+
+    // ==================== calculate_schema_entropy_upper_bound tests ====================
+
+    #[test]
+    fn test_upper_bound_with_local_refs() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "output_a": { "$ref": "#/$defs/agent_output" },
+                "output_b": { "$ref": "#/$defs/agent_output" }
+            },
+            "$defs": {
+                "agent_output": {
+                    "type": "object",
+                    "properties": {
+                        "decision": { "type": "string", "enum": ["PROCEED", "DO_NOT_PROCEED", "INCONCLUSIVE"] },
+                        "confidence_bucket": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH"] },
+                        "reason_code": { "type": "string", "enum": ["VALUES", "COMMUNICATION", "UNKNOWN"] },
+                        "self_adjustment_hint": { "type": "string", "enum": ["BE_MORE_DIRECT", "SLOW_DOWN", "NONE"] }
+                    }
+                }
+            }
+        });
+        // per agent: 2 + 2 + 2 + 2 = 8; two outputs => 16
+        assert_eq!(calculate_schema_entropy_upper_bound(&schema).unwrap(), 16);
+    }
+
+    #[test]
+    fn test_upper_bound_requires_metadata_for_unsupported_constructs() {
+        let unsupported = json!({
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "oneOf": [
+                        { "const": "PROCEED" },
+                        { "const": "DO_NOT_PROCEED" }
+                    ]
+                }
+            }
+        });
+        assert!(matches!(
+            calculate_schema_entropy_upper_bound(&unsupported),
+            Err(EntropyError::MissingUpperBoundMetadata { .. })
+        ));
+
+        let with_metadata = json!({
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "oneOf": [
+                        { "const": "PROCEED" },
+                        { "const": "DO_NOT_PROCEED" }
+                    ],
+                    "x-vcav-entropy-bits-upper-bound": 1
+                }
+            }
+        });
+        assert_eq!(
+            calculate_schema_entropy_upper_bound(&with_metadata).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_upper_bound_const_is_zero_bits() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": { "const": "PROCEED" }
+            }
+        });
+        assert_eq!(calculate_schema_entropy_upper_bound(&schema).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_upper_bound_reports_unresolvable_ref() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": { "$ref": "#/$defs/missing" }
+            }
+        });
+        let err = calculate_schema_entropy_upper_bound(&schema)
+            .expect_err("missing local ref should fail with explicit error");
+        assert!(matches!(err, EntropyError::UnresolvableLocalRef { .. }));
+    }
+
+    #[test]
+    fn test_entropy_ceiling_validation_fails_on_undercount() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "decision": { "type": "string", "enum": ["PROCEED", "DO_NOT_PROCEED", "INCONCLUSIVE"] },
+                "confidence_bucket": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH"] },
+                "reason_code": { "type": "string", "enum": ["A", "B", "C", "D", "E"] }
+            }
+        });
+        // upper bound = 2 + 2 + 3 = 7; ceiling 6 must fail
+        assert!(matches!(
+            ensure_schema_entropy_within_ceiling(&schema, 6),
+            Err(EntropyError::EntropyCeilingExceeded {
+                upper: 7,
+                ceiling: 6
+            })
+        ));
+    }
+
+    // ==================== Property-based tests ====================
+
+    #[test]
+    fn test_entropy_monotonic() {
+        let mut prev = 0u16;
+        for cardinality in 1..=1000 {
+            let bits = enum_entropy_bits(cardinality);
+            assert!(
+                bits >= prev,
+                "Entropy should be monotonically non-decreasing"
+            );
+            prev = bits;
+        }
+    }
+
+    #[test]
+    fn test_entropy_upper_bound_formula() {
+        for cardinality in 2..=1000 {
+            let bits = enum_entropy_bits(cardinality);
+            let expected_max = (cardinality as f64).log2().ceil() as u16;
+            assert_eq!(bits, expected_max);
+        }
+    }
+}

--- a/packages/entropy-core/src/store.rs
+++ b/packages/entropy-core/src/store.rs
@@ -1,0 +1,111 @@
+//! Persistence interface for entropy ledger entries.
+//!
+//! ## Ordering contract (enforced, not advisory)
+//!
+//! `append()` MUST reject entries that violate the strict total order
+//! `(timestamp, session_id)`. `entries()` MUST return entries in canonical
+//! order. This is not caller discipline — ordering is load-bearing because
+//! entropy status commitments, ledger head hashes, and delta commitments
+//! depend on it. A store that returns entries in a different order produces
+//! unverifiable receipts.
+
+use crate::ledger::{EntropyLedger, EntropyLedgerEntry, EntropyLedgerError};
+
+/// Persistence interface for entropy ledger entries.
+///
+/// Implementations must enforce the `(timestamp, session_id)` total order
+/// on `append()` and return entries in canonical order from `entries()`.
+pub trait EntropyLedgerStore: Send + Sync {
+    /// Append an entry, rejecting if it violates canonical ordering.
+    fn append(&mut self, entry: EntropyLedgerEntry) -> Result<(), EntropyLedgerError>;
+
+    /// All entries in canonical `(timestamp, session_id)` order.
+    fn entries(&self) -> &[EntropyLedgerEntry];
+}
+
+/// In-memory store backed by `EntropyLedger`.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryEntropyLedgerStore {
+    ledger: EntropyLedger,
+}
+
+impl InMemoryEntropyLedgerStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Borrow the underlying ledger for status computation.
+    pub fn ledger(&self) -> &EntropyLedger {
+        &self.ledger
+    }
+}
+
+impl EntropyLedgerStore for InMemoryEntropyLedgerStore {
+    fn append(&mut self, entry: EntropyLedgerEntry) -> Result<(), EntropyLedgerError> {
+        self.ledger.append(entry)
+    }
+
+    fn entries(&self) -> &[EntropyLedgerEntry] {
+        self.ledger.entries()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn ts(year: i32, month: u32, day: u32, hour: u32) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).unwrap()
+    }
+
+    fn make_entry(
+        session_id: &str,
+        ts: chrono::DateTime<Utc>,
+    ) -> EntropyLedgerEntry {
+        EntropyLedgerEntry {
+            session_id: session_id.to_string(),
+            pair_id: "pair".to_string(),
+            contract_key: "contract:none:v1".to_string(),
+            entropy_millibits: 100,
+            timestamp: ts,
+            receipt_hash: format!("hash-{session_id}"),
+        }
+    }
+
+    #[test]
+    fn test_in_memory_store_append_and_read() {
+        let mut store = InMemoryEntropyLedgerStore::new();
+        let t1 = ts(2025, 1, 1, 0);
+        let t2 = ts(2025, 1, 1, 1);
+
+        store.append(make_entry("s1", t1)).unwrap();
+        store.append(make_entry("s2", t2)).unwrap();
+
+        assert_eq!(store.entries().len(), 2);
+        assert_eq!(store.entries()[0].session_id, "s1");
+        assert_eq!(store.entries()[1].session_id, "s2");
+    }
+
+    #[test]
+    fn test_in_memory_store_rejects_ordering_violation() {
+        let mut store = InMemoryEntropyLedgerStore::new();
+        let t1 = ts(2025, 1, 1, 1);
+        let t0 = ts(2025, 1, 1, 0);
+
+        store.append(make_entry("s1", t1)).unwrap();
+        let err = store.append(make_entry("s2", t0)).unwrap_err();
+        assert!(matches!(err, EntropyLedgerError::TimestampRegression { .. }));
+    }
+
+    #[test]
+    fn test_in_memory_store_ledger_access() {
+        let mut store = InMemoryEntropyLedgerStore::new();
+        store
+            .append(make_entry("s1", ts(2025, 1, 1, 0)))
+            .unwrap();
+
+        let ledger = store.ledger();
+        assert_eq!(ledger.entries().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts generic entropy ledger accounting and schema measurement from vcav guardian-core into VFC
- Creates `entropy-core` crate with `ledger`, `measurement`, and `store` modules
- Includes test vector generation binary (`entropy-generate-vectors`) matching golden vectors
- 39 unit tests including cross-language fixture validation and explicit negative ordering tests

## Design decisions
- **Accounting, not safety:** entropy-core measures and tracks; enforcement stays in consuming runtimes
- **Strict total order:** `(timestamp, session_id)` with documented tie-breakers and enforced rejection
- **Policy-neutral errors:** no VCAV-specific language in error messages
- **Frozen wire format:** `vcav/` domain prefixes are cryptographic constants, not policy claims

Refs vcav-io/vcav#744

## Test plan
- [x] `cargo test -p entropy-core` passes (39 tests)
- [x] `cargo run --bin entropy-generate-vectors` output matches golden entropy-status-v1.json
- [ ] vcav guardian-core re-export PR (separate, depends on this merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)