### PR TITLE
docs: public readiness — governance, README, crate doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.1.0 (2026-02-24)
 
-Initial release. Extracted from the [vcav monorepo](https://github.com/vcav-io/vcav)
-as a standalone repository.
+Initial release. Extracted from the vcav monorepo as a standalone repository.
 
 ### Crates
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the repository's GitHub Security Advisories contact. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to vault-family-core
+
+## Prerequisites
+
+- **Rust 1.88+** — pinned in `rust-toolchain.toml`. `rustup` will install the correct
+  toolchain automatically when you run any `cargo` command inside the repo.
+- **wasm-pack 0.13.1+** — required only if you are working on the WASM crates
+  (`ifc-wasm`, `verifier-wasm`). Install with:
+  ```bash
+  cargo install wasm-pack --version "^0.13"
+  ```
+
+## Build and Test
+
+```bash
+# Build all crates
+cargo build --workspace
+
+# Run all tests
+cargo test --workspace
+
+# Lint (must be clean — CI enforces -D warnings)
+cargo clippy --workspace -- -D warnings
+
+# Check formatting (does not modify files)
+cargo fmt --all -- --check
+
+# Fix formatting in-place
+cargo fmt --all
+```
+
+WASM crates can be built with:
+
+```bash
+wasm-pack build packages/ifc-wasm
+wasm-pack build packages/verifier-wasm
+```
+
+## Frozen Wire Formats
+
+Some types have **frozen serialization**: their JSON/binary representation is
+part of the protocol and changing it breaks existing signatures and receipts.
+These types are annotated with a `# FROZEN` doc comment near their definition.
+
+Contributions that alter a frozen wire format — even in a seemingly compatible
+way — require explicit review and a corresponding bump in the schema version.
+Please call this out clearly in your PR description.
+
+## PR Conventions
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes. Ensure `cargo test --workspace` and
+   `cargo clippy --workspace -- -D warnings` both pass locally.
+3. Open a pull request against `main`. Fill in the PR description with
+   what changed and why.
+4. CI must pass before a PR can be merged. A maintainer will review and merge.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+Please read it before participating.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Constitutional shared core for the VCAV protocol family. Small, stable, boring.
 
+Provides the shared type vocabulary, cryptographic signing, receipt verification, and information-flow-control primitives consumed by [AgentVault](https://github.com/vcav-io/agentvault) and other protocol implementations.
+
 ## What's here
 
 - **ifc-engine** -- Label algebra, policy evaluation, canonical representation
@@ -13,6 +15,8 @@ Constitutional shared core for the VCAV protocol family. Small, stable, boring.
 - **verifier-wasm** -- Browser WASM verification
 - **vault-family-types** -- Shared protocol vocabulary (Purpose, BudgetTier, agent ID normalisation)
 - **escalation-interface** -- Minimal escalation seam between AgentVault and VCAV
+- **afal-core** -- AFAL wire types and signing
+- **entropy-core** -- Entropy ledger and budget tracking
 
 ## Building
 
@@ -25,11 +29,14 @@ Requires Rust 1.88.0+ (see `rust-toolchain.toml`).
 
 WASM builds (`ifc-wasm`, `verifier-wasm`) require `wasm-pack` 0.13.1+.
 
+## Schemas
+
+JSON Schemas for receipt and AFAL wire formats live in `schemas/`.
+
 ## Ecosystem
 
-vault-family-core is consumed by:
+vault-family-core is part of a broader protocol family for agent coordination. It is consumed by:
 
-- [vcav](https://github.com/vcav-io/vcav) -- Hardened sealed-execution protocol
 - [agentvault](https://github.com/vcav-io/agentvault) -- Open agent-native bounded-disclosure protocol
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+vault-family-core implements the cryptographic foundation of the VCAV protocol family.
+Security researchers who discover vulnerabilities are asked to disclose responsibly
+via **GitHub Security Advisories** rather than opening a public issue.
+
+To report a vulnerability:
+
+1. Go to the [Security tab](../../security/advisories) of this repository.
+2. Click **New draft security advisory**.
+3. Describe the vulnerability, affected versions, and (if known) a minimal reproduction.
+4. Submit the draft — maintainers will respond within 5 business days.
+
+## Scope
+
+The following components are in scope for security research:
+
+- **Ed25519 signing and verification** (`receipt-core`, `message-envelope`, `afal-core`)
+- **Receipt generation and tamper detection** (`receipt-core`)
+- **Canonicalization / RFC 8785 JCS implementation** (`receipt-core::canonicalize`)
+- **IFC label algebra and policy evaluation** (`ifc-engine`)
+- **AFAL wire types and signing** (`afal-core`)
+- **JSON Schema validation** (`verifier-core::schema_validator`)
+- **WASM verification surface** (`verifier-wasm`, `ifc-wasm`)
+
+Out-of-scope: build tooling, CI configuration, documentation errors.
+
+## Disclosure Policy
+
+- Maintainers will acknowledge receipt within 5 business days.
+- A fix will be prepared in a private fork and coordinated with the reporter before public disclosure.
+- Credit will be given in the release notes unless the reporter requests anonymity.

--- a/packages/escalation-interface/src/lib.rs
+++ b/packages/escalation-interface/src/lib.rs
@@ -61,7 +61,7 @@ pub enum EscalationResult {
 
 /// Trait implemented by VCAV to handle incoming escalation requests.
 ///
-/// // TODO: implement in vcav
+/// Implementation provided by the sealed-execution layer. This crate defines the interface only.
 pub trait EscalationHandler {
     /// Evaluate an escalation request and return the outcome.
     fn evaluate(&self, req: EscalationRequest) -> EscalationResult;

--- a/packages/receipt-core/src/lib.rs
+++ b/packages/receipt-core/src/lib.rs
@@ -17,6 +17,9 @@
 //! - [`canonicalize`] - RFC 8785 JSON Canonicalization Scheme
 //! - [`signer`] - Ed25519 signing with domain separation
 //! - [`manifest`] - Signed publication manifest for operator artefact bundles
+//! - [`agreement`] - Session agreement hash computation
+//! - [`attestation`] - Attestation challenge and evidence types
+//! - [`ledger`] - Budget ledger with apply/check semantics
 
 pub mod agreement;
 pub mod attestation;

--- a/packages/verifier-core/src/lib.rs
+++ b/packages/verifier-core/src/lib.rs
@@ -2,7 +2,28 @@
 //! # Verifier Core
 //!
 //! WASM-compatible verification logic for VCAV receipts.
-//! All functions accept `&str` / `&[u8]` inputs — no filesystem or CLI dependencies.
+//!
+//! This crate provides the verification primitives used by both the browser WASM
+//! surface (`verifier-wasm`) and the offline CLI (`verifier-cli`). All functions
+//! accept `&str` / `&[u8]` inputs — no filesystem or network dependencies.
+//!
+//! ## Verification Tiers
+//!
+//! Receipt verification is structured in three tiers of increasing strictness:
+//!
+//! - **Tier 1 — Signature check**: Verify the Ed25519 signature over the canonical
+//!   receipt bytes. This is the minimum check for any receipt consumer.
+//! - **Tier 2 — Schema + policy validation**: Validate the receipt against the
+//!   embedded JSON Schema and check that declared policy hashes are well-formed.
+//! - **Tier 3 — Full chain verification**: Reconstruct and verify the full budget
+//!   chain, validate model identity against the operator profile, and check
+//!   compartment IDs and contract enforcement.
+//!
+//! ## Schema Validation
+//!
+//! Embedded schemas (compiled into the binary at build time via `build.rs`) are
+//! exposed through [`schema_validator::SCHEMAS`] for use in both local validation
+//! and downstream crates.
 
 pub mod schema_validator;
 pub mod tiers;


### PR DESCRIPTION
## Summary

- **SECURITY.md** — Coordinated disclosure via GitHub Security Advisories. Scoped to Ed25519 signing/verification, receipt tamper detection, IFC engine, AFAL wire types, and JSON schema validation.
- **CONTRIBUTING.md** — Prerequisites (Rust 1.88+, wasm-pack 0.13.1+), build/test/lint commands, note on frozen wire formats, PR conventions.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 full text.
- **README.md** — Remove private `vcav` repo link from Ecosystem; add cold-reader one-liner after tagline; add `afal-core` and `entropy-core` to the What's here list; add `## Schemas` section.
- **CHANGELOG.md** — Remove private `vcav` monorepo link.
- **receipt-core/src/lib.rs** — Add `agreement`, `attestation`, and `ledger` to the `## Modules` doc list (they were `pub mod` entries with no mention in the crate-level comment).
- **verifier-core/src/lib.rs** — Expand 2-line doc comment to ~20 lines explaining WASM-compatibility, the three verification tiers, and schema validation utilities.
- **escalation-interface/src/lib.rs** — Convert `// TODO: implement in vcav` inline comment to a proper `///` doc comment so it renders correctly in `cargo doc`.

## Test plan

- [x] `cargo test --workspace` passes locally
- [x] `cargo clippy --workspace -- -D warnings` passes locally
- [x] `cargo fmt --all -- --check` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)