### PR TITLE
feat(verifier-core): embed 11 vault_result schemas for offline verification

### DIFF
--- a/packages/verifier-core/build.rs
+++ b/packages/verifier-core/build.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 /// Simplified build script for verifier-core.
 ///
-/// Copies the 5 vault-family-core schemas to OUT_DIR/family/ for embedding
+/// Copies the 16 vault-family-core schemas to OUT_DIR/family/ for embedding
 /// via include_str!. No cross-workspace paths — schemas are resolved relative
 /// to CARGO_MANIFEST_DIR (../../schemas/).
 fn main() {
@@ -21,6 +21,17 @@ fn main() {
         "encrypted_input.schema.json",
         "signed_input.schema.json",
         "input_ciphertext_envelope_v1.schema.json",
+        "vault_result_compatibility.schema.json",
+        "vault_result_compatibility_d2.schema.json",
+        "vault_result_dating_compat_v1.schema.json",
+        "vault_result_injection_escalation.schema.json",
+        "vault_result_mediation.schema.json",
+        "vault_result_mediation_e6.schema.json",
+        "vault_result_mediation_e10.schema.json",
+        "vault_result_mediation_e18.schema.json",
+        "vault_result_negotiation.schema.json",
+        "vault_result_scheduling.schema.json",
+        "vault_result_scheduling_compat_v1.schema.json",
     ];
 
     for name in &schemas {

--- a/packages/verifier-core/src/schema_validator.rs
+++ b/packages/verifier-core/src/schema_validator.rs
@@ -1,8 +1,9 @@
 //! Embedded JSON schema constants for offline verification.
 //!
-//! These schemas are embedded at compile time via build.rs. Only vault-family-core
-//! envelope schemas are included. Protocol-specific schemas (vcav, agentvault) must
-//! be provided at runtime via --schema-dir or schema bundles.
+//! These schemas are embedded at compile time via build.rs. vault-family-core
+//! envelope schemas and vault result schemas are included. Protocol-specific
+//! schemas (vcav, agentvault) must be provided at runtime via --schema-dir or
+//! schema bundles.
 
 /// A named embedded schema entry.
 pub struct EmbeddedSchemaEntry {
@@ -28,6 +29,52 @@ pub const INPUT_CIPHERTEXT_ENVELOPE_V1_SCHEMA: &str = include_str!(concat!(
     "/family/input_ciphertext_envelope_v1.schema.json"
 ));
 
+// vault result schemas
+pub const VAULT_RESULT_COMPATIBILITY_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_compatibility.schema.json"
+));
+pub const VAULT_RESULT_COMPATIBILITY_D2_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_compatibility_d2.schema.json"
+));
+pub const VAULT_RESULT_DATING_COMPAT_V1_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_dating_compat_v1.schema.json"
+));
+pub const VAULT_RESULT_INJECTION_ESCALATION_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_injection_escalation.schema.json"
+));
+pub const VAULT_RESULT_MEDIATION_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_mediation.schema.json"
+));
+pub const VAULT_RESULT_MEDIATION_E6_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_mediation_e6.schema.json"
+));
+pub const VAULT_RESULT_MEDIATION_E10_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_mediation_e10.schema.json"
+));
+pub const VAULT_RESULT_MEDIATION_E18_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_mediation_e18.schema.json"
+));
+pub const VAULT_RESULT_NEGOTIATION_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_negotiation.schema.json"
+));
+pub const VAULT_RESULT_SCHEDULING_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_scheduling.schema.json"
+));
+pub const VAULT_RESULT_SCHEDULING_COMPAT_V1_SCHEMA: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/family/vault_result_scheduling_compat_v1.schema.json"
+));
+
 /// All embedded schemas as a static array.
 pub const SCHEMAS: &[EmbeddedSchemaEntry] = &[
     EmbeddedSchemaEntry {
@@ -50,6 +97,50 @@ pub const SCHEMAS: &[EmbeddedSchemaEntry] = &[
         filename: "input_ciphertext_envelope_v1.schema.json",
         content: INPUT_CIPHERTEXT_ENVELOPE_V1_SCHEMA,
     },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_compatibility.schema.json",
+        content: VAULT_RESULT_COMPATIBILITY_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_compatibility_d2.schema.json",
+        content: VAULT_RESULT_COMPATIBILITY_D2_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_dating_compat_v1.schema.json",
+        content: VAULT_RESULT_DATING_COMPAT_V1_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_injection_escalation.schema.json",
+        content: VAULT_RESULT_INJECTION_ESCALATION_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_mediation.schema.json",
+        content: VAULT_RESULT_MEDIATION_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_mediation_e6.schema.json",
+        content: VAULT_RESULT_MEDIATION_E6_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_mediation_e10.schema.json",
+        content: VAULT_RESULT_MEDIATION_E10_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_mediation_e18.schema.json",
+        content: VAULT_RESULT_MEDIATION_E18_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_negotiation.schema.json",
+        content: VAULT_RESULT_NEGOTIATION_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_scheduling.schema.json",
+        content: VAULT_RESULT_SCHEDULING_SCHEMA,
+    },
+    EmbeddedSchemaEntry {
+        filename: "vault_result_scheduling_compat_v1.schema.json",
+        content: VAULT_RESULT_SCHEDULING_COMPAT_V1_SCHEMA,
+    },
 ];
 
 #[cfg(test)]
@@ -70,6 +161,6 @@ mod tests {
 
     #[test]
     fn test_schema_count() {
-        assert_eq!(SCHEMAS.len(), 5, "Should have 5 embedded family schemas");
+        assert_eq!(SCHEMAS.len(), 16, "Should have 16 embedded family schemas");
     }
 }

--- a/schemas/vault_result_compatibility.schema.json
+++ b/schemas/vault_result_compatibility.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_compatibility.schema.json",
+  "title": "VaultResultCompatibility",
+  "description": "Constant-shape output for COMPATIBILITY purpose. Max entropy: 8 bits.",
+  "type": "object",
+  "properties": {
+    "decision": {
+      "type": "string",
+      "enum": [
+        "PROCEED",
+        "DO_NOT_PROCEED",
+        "INCONCLUSIVE"
+      ],
+      "description": "Primary decision signal (3 values = ~1.58 bits)"
+    },
+    "confidence_bucket": {
+      "type": "string",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ],
+      "description": "Confidence level (3 values = ~1.58 bits)"
+    },
+    "reason_code": {
+      "type": "string",
+      "enum": [
+        "GOALS_MISMATCH",
+        "COMMUNICATION_STYLE",
+        "LOGISTICS",
+        "MUTUAL_INTEREST_UNCLEAR",
+        "RESERVED_01",
+        "RESERVED_02",
+        "RESERVED_03",
+        "RESERVED_04",
+        "RESERVED_05",
+        "RESERVED_06",
+        "RESERVED_07",
+        "RESERVED_08",
+        "UNKNOWN"
+      ],
+      "description": "Reason classification (13 values = ~3.7 bits). RESERVED codes for future use."
+    }
+  },
+  "required": [
+    "decision",
+    "confidence_bucket",
+    "reason_code"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this conversation between two agents evaluating compatibility, provide a structured assessment.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- decision: \"PROCEED\" | \"DO_NOT_PROCEED\" | \"INCONCLUSIVE\"\n- confidence_bucket: \"LOW\" | \"MEDIUM\" | \"HIGH\"\n- reason_code: \"GOALS_MISMATCH\" | \"COMMUNICATION_STYLE\" | \"LOGISTICS\" | \"MUTUAL_INTEREST_UNCLEAR\" | \"RESERVED_01\" | \"RESERVED_02\" | \"RESERVED_03\" | \"RESERVED_04\" | \"RESERVED_05\" | \"RESERVED_06\" | \"RESERVED_07\" | \"RESERVED_08\" | \"UNKNOWN\"",
+  "$comment": "Total entropy: ~6.86 bits. Budgeted as 8 bits."
+}

--- a/schemas/vault_result_compatibility_d2.schema.json
+++ b/schemas/vault_result_compatibility_d2.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_compatibility_d2.schema.json",
+  "title": "VaultResultCompatibilityD2",
+  "description": "Dual-output for D2 dating template. Two bounded outputs, one per agent. Max entropy: 20 bits.",
+  "type": "object",
+  "properties": {
+    "output_a": {
+      "$ref": "#/$defs/agent_output"
+    },
+    "output_b": {
+      "$ref": "#/$defs/agent_output"
+    }
+  },
+  "required": [
+    "output_a",
+    "output_b"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "agent_output": {
+      "type": "object",
+      "properties": {
+        "decision": {
+          "type": "string",
+          "enum": [
+            "PROCEED",
+            "DO_NOT_PROCEED",
+            "INCONCLUSIVE"
+          ],
+          "description": "Primary decision signal (3 values = 2 bits)"
+        },
+        "confidence_bucket": {
+          "type": "string",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "description": "Confidence level (3 values = 2 bits)"
+        },
+        "reason_code": {
+          "type": "string",
+          "enum": [
+            "VALUES",
+            "COMMUNICATION",
+            "LOGISTICS",
+            "INTEREST_UNCLEAR",
+            "TIMING",
+            "LIFESTYLE",
+            "UNKNOWN"
+          ],
+          "description": "Reason classification (7 values = 3 bits)"
+        },
+        "self_adjustment_hint": {
+          "type": "string",
+          "enum": [
+            "BE_MORE_DIRECT",
+            "SLOW_DOWN",
+            "ASK_FEWER_QUESTIONS",
+            "OFFER_REASSURANCE",
+            "STATE_CONSTRAINTS",
+            "KEEP_IT_LIGHT",
+            "NONE"
+          ],
+          "description": "Self-adjustment coaching hint (7 values = 3 bits). For self, not about other party."
+        }
+      },
+      "required": [
+        "decision",
+        "confidence_bucket",
+        "reason_code",
+        "self_adjustment_hint"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "x-vcav-prompt-instruction": "Analyze both perspectives from a dating interaction and provide personalized guidance for each party.\n\nFor EACH agent, determine:\n1. decision: Should they proceed? (PROCEED, DO_NOT_PROCEED, or INCONCLUSIVE)\n2. confidence_bucket: How confident is this assessment? (LOW, MEDIUM, HIGH)\n3. reason_code: Main factor (VALUES, COMMUNICATION, LOGISTICS, INTEREST_UNCLEAR, TIMING, LIFESTYLE, UNKNOWN)\n4. self_adjustment_hint: What could THIS agent do differently? (BE_MORE_DIRECT, SLOW_DOWN, ASK_FEWER_QUESTIONS, OFFER_REASSURANCE, STATE_CONSTRAINTS, KEEP_IT_LIGHT, NONE)\n\nIMPORTANT: self_adjustment_hint is coaching for THAT agent about their own behavior, NOT about the other party.",
+  "x-vcav-prompt-output-format": "Respond with valid JSON containing output_a (for Agent A) and output_b (for Agent B):",
+  "$comment": "Per-agent: 10 bits (2+2+3+3). Total: 20 bits (2 agents). Budget: 20 bits."
+}

--- a/schemas/vault_result_dating_compat_v1.schema.json
+++ b/schemas/vault_result_dating_compat_v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_dating_compat_v1.schema.json",
+  "title": "VaultResultDatingCompatV1",
+  "description": "Capability-track constant-shape output for dating compatibility evaluation.",
+  "type": "object",
+  "properties": {
+    "compatibility_bucket": {
+      "type": "string",
+      "enum": [
+        "NEGATIVE",
+        "MIXED",
+        "POSITIVE"
+      ],
+      "description": "Primary bucketed compatibility class for gate evaluation."
+    },
+    "compatibility_signal": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5,
+      "description": "Ordinal compatibility class where 0=strong mismatch, 5=strong match."
+    }
+  },
+  "required": [
+    "compatibility_bucket",
+    "compatibility_signal"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this dating compatibility data, evaluate the overall compatibility between the two parties.",
+  "x-vcav-prompt-context": "Compatibility data:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- compatibility_bucket: \"NEGATIVE\" | \"MIXED\" | \"POSITIVE\"\n- compatibility_signal: integer from 0 (strong mismatch) to 5 (strong match)"
+}

--- a/schemas/vault_result_injection_escalation.schema.json
+++ b/schemas/vault_result_injection_escalation.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_injection_escalation.schema.json",
+  "title": "Injection Escalation Result",
+  "description": "Bounded risk signal for content escalated into a VCAV enclave. All fields are required enums — no free text.",
+  "type": "object",
+  "properties": {
+    "risk_level": {
+      "type": "string",
+      "enum": ["SAFE", "SUSPICIOUS", "MALICIOUS", "ABSTAIN"]
+    },
+    "attack_surface": {
+      "type": "string",
+      "enum": ["PROMPT_OVERRIDE", "TOOL_INJECTION", "DATA_POISONING", "CREDENTIAL_HARVEST", "SOCIAL_ENGINEERING", "UNKNOWN"]
+    },
+    "handling_signal": {
+      "type": "string",
+      "enum": ["PROCEED", "PROCEED_WITH_STRICT_ALLOWLIST", "REQUIRE_HUMAN_CONFIRM", "BLOCK_THIS_INPUT"]
+    }
+  },
+  "required": ["risk_level", "attack_surface", "handling_signal"],
+  "additionalProperties": false
+}

--- a/schemas/vault_result_mediation.schema.json
+++ b/schemas/vault_result_mediation.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_mediation.schema.json",
+  "title": "VaultResultMediation",
+  "description": "Capability-track constant-shape output for MEDIATION purpose. Max entropy: 13 bits.",
+  "type": "object",
+  "properties": {
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "PROGRESS",
+        "STUCK",
+        "ESCALATE"
+      ],
+      "description": "Mediation progress (3 values = ~1.58 bits)"
+    },
+    "a_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party A (8 values = 3.00 bits)"
+    },
+    "b_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party B (8 values = 3.00 bits)"
+    },
+    "shared_move": {
+      "type": "string",
+      "enum": [
+        "ENUMERATE_CONTRIBUTIONS",
+        "SET_GROUND_RULES",
+        "TIMEBOX",
+        "PAUSE",
+        "SEEK_EXTERNAL_INPUT",
+        "NONE"
+      ],
+      "description": "Recommended shared action (6 values = ~2.58 bits)"
+    },
+    "conflict_type": {
+      "type": "string",
+      "enum": [
+        "RECOGNITION",
+        "RESOURCE",
+        "PROCESS",
+        "VALUES",
+        "UNKNOWN"
+      ],
+      "description": "Classification of conflict type (5 values = ~2.32 bits)"
+    }
+  },
+  "required": [
+    "outcome",
+    "a_move",
+    "b_move",
+    "shared_move",
+    "conflict_type"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this mediation conversation, assess the situation and recommend next moves.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- outcome: \"PROGRESS\" | \"STUCK\" | \"ESCALATE\"\n- a_move: \"ACKNOWLEDGE\" | \"RESTATE_NEEDS\" | \"OFFER_REPAIR\" | \"REQUEST_CLARITY\" | \"REQUEST_ACKNOWLEDGMENT\" | \"SET_BOUNDARY\" | \"PROPOSE_COMPROMISE\" | \"NONE\"\n- b_move: (same options as a_move)\n- shared_move: \"ENUMERATE_CONTRIBUTIONS\" | \"SET_GROUND_RULES\" | \"TIMEBOX\" | \"PAUSE\" | \"SEEK_EXTERNAL_INPUT\" | \"NONE\"\n- conflict_type: \"RECOGNITION\" | \"RESOURCE\" | \"PROCESS\" | \"VALUES\" | \"UNKNOWN\"",
+  "$comment": "Total entropy: ~12.48 bits. Capability-track labels intentionally exclude reserved expansion slots."
+}

--- a/schemas/vault_result_mediation_e10.schema.json
+++ b/schemas/vault_result_mediation_e10.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_mediation_e10.schema.json",
+  "title": "VaultResultMediationE10",
+  "description": "E10 mediation schema variant: anchor (E12) minus shared_move. 960 outputs ≈ 9.91 bits.",
+  "type": "object",
+  "properties": {
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "PROGRESS",
+        "STUCK",
+        "ESCALATE"
+      ],
+      "description": "Mediation progress (3 values = ~1.58 bits)"
+    },
+    "a_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party A (8 values = 3.00 bits)"
+    },
+    "b_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party B (8 values = 3.00 bits)"
+    },
+    "conflict_type": {
+      "type": "string",
+      "enum": [
+        "RECOGNITION",
+        "RESOURCE",
+        "PROCESS",
+        "VALUES",
+        "UNKNOWN"
+      ],
+      "description": "Classification of conflict type (5 values = ~2.32 bits)"
+    }
+  },
+  "required": [
+    "outcome",
+    "a_move",
+    "b_move",
+    "conflict_type"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this mediation conversation, assess the situation and recommend next moves.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- outcome: \"PROGRESS\" | \"STUCK\" | \"ESCALATE\"\n- a_move: \"ACKNOWLEDGE\" | \"RESTATE_NEEDS\" | \"OFFER_REPAIR\" | \"REQUEST_CLARITY\" | \"REQUEST_ACKNOWLEDGMENT\" | \"SET_BOUNDARY\" | \"PROPOSE_COMPROMISE\" | \"NONE\"\n- b_move: (same options as a_move)\n- conflict_type: \"RECOGNITION\" | \"RESOURCE\" | \"PROCESS\" | \"VALUES\" | \"UNKNOWN\"",
+  "$comment": "Total entropy: ~9.91 bits (960 outputs). E12 anchor minus shared_move field."
+}

--- a/schemas/vault_result_mediation_e18.schema.json
+++ b/schemas/vault_result_mediation_e18.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_mediation_e18.schema.json",
+  "title": "VaultResultMediationE18",
+  "description": "Capability-track constant-shape output for MEDIATION purpose (E18 variant). Max entropy: 18.49 bits (368,640 outputs).",
+  "type": "object",
+  "properties": {
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "PROGRESS",
+        "STUCK",
+        "ESCALATE"
+      ],
+      "description": "Mediation progress (3 values = ~1.58 bits)"
+    },
+    "a_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party A (8 values = 3.00 bits)"
+    },
+    "b_move": {
+      "type": "string",
+      "enum": [
+        "ACKNOWLEDGE",
+        "RESTATE_NEEDS",
+        "OFFER_REPAIR",
+        "REQUEST_CLARITY",
+        "REQUEST_ACKNOWLEDGMENT",
+        "SET_BOUNDARY",
+        "PROPOSE_COMPROMISE",
+        "NONE"
+      ],
+      "description": "Recommended move for party B (8 values = 3.00 bits)"
+    },
+    "shared_move": {
+      "type": "string",
+      "enum": [
+        "ENUMERATE_CONTRIBUTIONS",
+        "SET_GROUND_RULES",
+        "TIMEBOX",
+        "PAUSE",
+        "SEEK_EXTERNAL_INPUT",
+        "NONE"
+      ],
+      "description": "Recommended shared action (6 values = ~2.58 bits)"
+    },
+    "conflict_type": {
+      "type": "string",
+      "enum": [
+        "RECOGNITION",
+        "RESOURCE",
+        "PROCESS",
+        "VALUES",
+        "UNKNOWN"
+      ],
+      "description": "Classification of conflict type (5 values = ~2.32 bits)"
+    },
+    "emotional_tone_a": {
+      "type": "string",
+      "enum": [
+        "CALM",
+        "CONCERNED",
+        "FRUSTRATED",
+        "ANXIOUS",
+        "HOSTILE",
+        "DISMISSIVE",
+        "HOPEFUL",
+        "RESIGNED"
+      ],
+      "description": "Observable emotional tone of party A's input (8 values = 3.00 bits)"
+    },
+    "emotional_tone_b": {
+      "type": "string",
+      "enum": [
+        "CALM",
+        "CONCERNED",
+        "FRUSTRATED",
+        "ANXIOUS",
+        "HOSTILE",
+        "DISMISSIVE",
+        "HOPEFUL",
+        "RESIGNED"
+      ],
+      "description": "Observable emotional tone of party B's input (8 values = 3.00 bits)"
+    }
+  },
+  "required": [
+    "outcome",
+    "a_move",
+    "b_move",
+    "shared_move",
+    "conflict_type",
+    "emotional_tone_a",
+    "emotional_tone_b"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this mediation conversation, assess the situation, recommend next moves, and classify the observable emotional tone from each party's input text.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- outcome: \"PROGRESS\" | \"STUCK\" | \"ESCALATE\"\n- a_move: \"ACKNOWLEDGE\" | \"RESTATE_NEEDS\" | \"OFFER_REPAIR\" | \"REQUEST_CLARITY\" | \"REQUEST_ACKNOWLEDGMENT\" | \"SET_BOUNDARY\" | \"PROPOSE_COMPROMISE\" | \"NONE\"\n- b_move: (same options as a_move)\n- shared_move: \"ENUMERATE_CONTRIBUTIONS\" | \"SET_GROUND_RULES\" | \"TIMEBOX\" | \"PAUSE\" | \"SEEK_EXTERNAL_INPUT\" | \"NONE\"\n- conflict_type: \"RECOGNITION\" | \"RESOURCE\" | \"PROCESS\" | \"VALUES\" | \"UNKNOWN\"\n- emotional_tone_a: \"CALM\" | \"CONCERNED\" | \"FRUSTRATED\" | \"ANXIOUS\" | \"HOSTILE\" | \"DISMISSIVE\" | \"HOPEFUL\" | \"RESIGNED\"\n- emotional_tone_b: \"CALM\" | \"CONCERNED\" | \"FRUSTRATED\" | \"ANXIOUS\" | \"HOSTILE\" | \"DISMISSIVE\" | \"HOPEFUL\" | \"RESIGNED\"",
+  "$comment": "Total entropy: ~18.49 bits (3×8×8×6×5×8×8 = 368,640 outputs). E18 extends E12 anchor with two fact-grounded emotional tone fields."
+}

--- a/schemas/vault_result_mediation_e6.schema.json
+++ b/schemas/vault_result_mediation_e6.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_mediation_e6.schema.json",
+  "title": "VaultResultMediationE6",
+  "description": "Capability-track constant-shape output for MEDIATION purpose (E6 coarse variant). Max entropy: 6 bits.",
+  "type": "object",
+  "properties": {
+    "stance_a": {
+      "type": "string",
+      "enum": [
+        "CONSTRUCTIVE",
+        "REQUESTING",
+        "DEFENDING",
+        "PASSIVE"
+      ],
+      "description": "Stance classification for party A (4 values = 2.00 bits)"
+    },
+    "stance_b": {
+      "type": "string",
+      "enum": [
+        "CONSTRUCTIVE",
+        "REQUESTING",
+        "DEFENDING",
+        "PASSIVE"
+      ],
+      "description": "Stance classification for party B (4 values = 2.00 bits)"
+    },
+    "situation": {
+      "type": "string",
+      "enum": [
+        "PROGRESS_INTERPERSONAL",
+        "PROGRESS_STRUCTURAL",
+        "STUCK",
+        "ESCALATE"
+      ],
+      "description": "Situational assessment of mediation state (4 values = 2.00 bits)"
+    }
+  },
+  "required": [
+    "stance_a",
+    "stance_b",
+    "situation"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this mediation conversation, classify each party's stance and the overall situation.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- stance_a: \"CONSTRUCTIVE\" | \"REQUESTING\" | \"DEFENDING\" | \"PASSIVE\"\n- stance_b: \"CONSTRUCTIVE\" | \"REQUESTING\" | \"DEFENDING\" | \"PASSIVE\"\n- situation: \"PROGRESS_INTERPERSONAL\" | \"PROGRESS_STRUCTURAL\" | \"STUCK\" | \"ESCALATE\"",
+  "$comment": "Total entropy: 6.00 bits (4 x 4 x 4 = 64 outputs). E6 is the coarsest mediation schema variant."
+}

--- a/schemas/vault_result_negotiation.schema.json
+++ b/schemas/vault_result_negotiation.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_negotiation.schema.json",
+  "title": "VaultResultNegotiation",
+  "description": "Constant-shape output for NEGOTIATION purpose. Max entropy: 24 bits.",
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "OFFER",
+        "COUNTER",
+        "ACCEPT",
+        "WALK_AWAY",
+        "ESCALATE",
+        "INCONCLUSIVE"
+      ],
+      "description": "Negotiation status (6 values = ~2.58 bits)"
+    },
+    "price_bucket": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "P01", "P02", "P03", "P04", "P05", "P06", "P07", "P08",
+        "P09", "P10", "P11", "P12", "P13", "P14", "P15", "P16"
+      ],
+      "description": "Price/value bucket from predefined ladder (17 values = ~4.09 bits)"
+    },
+    "term_a": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08"
+      ],
+      "description": "First term selection (9 values = ~3.17 bits)"
+    },
+    "term_b": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08"
+      ],
+      "description": "Second term selection (9 values = ~3.17 bits)"
+    },
+    "term_c": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08"
+      ],
+      "description": "Third term selection (9 values = ~3.17 bits)"
+    },
+    "flexibility_signal": {
+      "type": "string",
+      "enum": [
+        "FIRM",
+        "SLIGHT_FLEX",
+        "FLEXIBLE",
+        "VERY_FLEXIBLE"
+      ],
+      "description": "Signaled flexibility (4 values = 2 bits)"
+    },
+    "confidence_bucket": {
+      "type": "string",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ],
+      "description": "Confidence level (3 values = ~1.58 bits)"
+    }
+  },
+  "required": [
+    "status",
+    "price_bucket",
+    "term_a",
+    "term_b",
+    "term_c",
+    "flexibility_signal",
+    "confidence_bucket"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this negotiation conversation, assess the current state and next steps.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- status: \"OFFER\" | \"COUNTER\" | \"ACCEPT\" | \"WALK_AWAY\" | \"ESCALATE\" | \"INCONCLUSIVE\"\n- price_bucket: \"NONE\" | \"P01\" | \"P02\" | \"P03\" | \"P04\" | \"P05\" | \"P06\" | \"P07\" | \"P08\" | \"P09\" | \"P10\" | \"P11\" | \"P12\" | \"P13\" | \"P14\" | \"P15\" | \"P16\"\n- term_a: \"NONE\" | \"T01\" | \"T02\" | \"T03\" | \"T04\" | \"T05\" | \"T06\" | \"T07\" | \"T08\"\n- term_b: (same options as term_a)\n- term_c: (same options as term_a)\n- flexibility_signal: \"FIRM\" | \"SLIGHT_FLEX\" | \"FLEXIBLE\" | \"VERY_FLEXIBLE\"\n- confidence_bucket: \"LOW\" | \"MEDIUM\" | \"HIGH\"",
+  "$comment": "Total entropy: ~19.76 bits. Budgeted as 24 bits."
+}

--- a/schemas/vault_result_scheduling.schema.json
+++ b/schemas/vault_result_scheduling.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_scheduling.schema.json",
+  "title": "VaultResultScheduling",
+  "description": "Constant-shape output for SCHEDULING purpose. Max entropy: 16 bits.",
+  "type": "object",
+  "properties": {
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "FOUND",
+        "NONE",
+        "NEEDS_MORE_OPTIONS"
+      ],
+      "description": "Scheduling outcome (3 values = ~1.58 bits)"
+    },
+    "slot_1": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "S01", "S02", "S03", "S04", "S05", "S06",
+        "S07", "S08", "S09", "S10", "S11", "S12"
+      ],
+      "description": "First selected slot or NONE (13 values = ~3.7 bits)"
+    },
+    "slot_2": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "S01", "S02", "S03", "S04", "S05", "S06",
+        "S07", "S08", "S09", "S10", "S11", "S12"
+      ],
+      "description": "Second selected slot or NONE (13 values = ~3.7 bits)"
+    },
+    "slot_3": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "S01", "S02", "S03", "S04", "S05", "S06",
+        "S07", "S08", "S09", "S10", "S11", "S12"
+      ],
+      "description": "Third selected slot or NONE (13 values = ~3.7 bits)"
+    },
+    "confidence_bucket": {
+      "type": "string",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ],
+      "description": "Confidence level (3 values = ~1.58 bits)"
+    }
+  },
+  "required": [
+    "outcome",
+    "slot_1",
+    "slot_2",
+    "slot_3",
+    "confidence_bucket"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on this conversation about scheduling, determine the best mutually available time slots.",
+  "x-vcav-prompt-context": "Conversation:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- outcome: \"FOUND\" | \"NONE\" | \"NEEDS_MORE_OPTIONS\"\n- slot_1: \"NONE\" | \"S01\" | \"S02\" | \"S03\" | \"S04\" | \"S05\" | \"S06\" | \"S07\" | \"S08\" | \"S09\" | \"S10\" | \"S11\" | \"S12\"\n- slot_2: (same options as slot_1)\n- slot_3: (same options as slot_1)\n- confidence_bucket: \"LOW\" | \"MEDIUM\" | \"HIGH\"",
+  "$comment": "Total entropy: ~14.26 bits. Budgeted as 16 bits."
+}

--- a/schemas/vault_result_scheduling_compat_v1.schema.json
+++ b/schemas/vault_result_scheduling_compat_v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcav.io/schemas/vault_result_scheduling_compat_v1.schema.json",
+  "title": "VaultResultSchedulingCompatV1",
+  "description": "Constant-shape output for SCHEDULING_COMPAT_V1 contract including diagnostic intermediates.",
+  "type": "object",
+  "properties": {
+    "scheduling_signal": {
+      "type": "string",
+      "enum": [
+        "CLEAR_MATCH",
+        "PARTIAL_MATCH",
+        "NO_MATCH"
+      ],
+      "description": "Scheduling compatibility signal (3 values = ~2 bits)"
+    },
+    "constraint_type": {
+      "type": "string",
+      "enum": [
+        "TIME_CONFLICT",
+        "LOCATION_CONFLICT",
+        "DURATION_CONFLICT",
+        "MULTI_CONSTRAINT",
+        "NONE"
+      ],
+      "description": "Primary constraint type (5 values = ~2.32 bits)"
+    },
+    "max_overlap_minutes": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1440,
+      "description": "Largest same-day UTC overlap observed across all window pairs.",
+      "x-vcav-entropy-bits-upper-bound": 11
+    },
+    "required_duration_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 240,
+      "description": "Required duration computed as max(A.min_duration_minutes, B.min_duration_minutes).",
+      "x-vcav-entropy-bits-upper-bound": 8
+    },
+    "location_compatible": {
+      "type": "boolean",
+      "description": "True when location constraints are jointly satisfiable.",
+      "x-vcav-entropy-bits-upper-bound": 1
+    },
+    "overlaps_by_day": {
+      "type": "object",
+      "properties": {
+        "MON": { "type": "integer", "minimum": 0, "maximum": 1440, "x-vcav-entropy-bits-upper-bound": 11 },
+        "TUE": { "type": "integer", "minimum": 0, "maximum": 1440, "x-vcav-entropy-bits-upper-bound": 11 },
+        "WED": { "type": "integer", "minimum": 0, "maximum": 1440, "x-vcav-entropy-bits-upper-bound": 11 },
+        "THU": { "type": "integer", "minimum": 0, "maximum": 1440, "x-vcav-entropy-bits-upper-bound": 11 },
+        "FRI": { "type": "integer", "minimum": 0, "maximum": 1440, "x-vcav-entropy-bits-upper-bound": 11 }
+      },
+      "required": ["MON", "TUE", "WED", "THU", "FRI"],
+      "additionalProperties": false,
+      "description": "Per-day maximum overlap in UTC minutes across all same-day window pairs."
+    },
+    "max_overlap_check": {
+      "type": "boolean",
+      "description": "Model self-check that max_overlap_minutes equals the maximum listed overlap.",
+      "x-vcav-entropy-bits-upper-bound": 1
+    }
+  },
+  "required": [
+    "scheduling_signal",
+    "constraint_type",
+    "max_overlap_minutes",
+    "required_duration_minutes",
+    "location_compatible",
+    "overlaps_by_day",
+    "max_overlap_check"
+  ],
+  "additionalProperties": false,
+  "x-vcav-prompt-instruction": "Based on the scheduling data from two agents, determine whether their availability schedules are compatible.",
+  "x-vcav-prompt-context": "Scheduling data:\n{dialogue}",
+  "x-vcav-prompt-output-format": "Respond with valid JSON using ONLY these values:\n- scheduling_signal: \"CLEAR_MATCH\" | \"PARTIAL_MATCH\" | \"NO_MATCH\"\n- constraint_type: \"TIME_CONFLICT\" | \"LOCATION_CONFLICT\" | \"DURATION_CONFLICT\" | \"MULTI_CONSTRAINT\" | \"NONE\"\n- max_overlap_minutes: integer from 0 to 1440 (largest same-day UTC overlap in minutes)\n- required_duration_minutes: integer from 1 to 240 (required meeting duration in minutes)\n- location_compatible: true | false (whether location constraints are jointly satisfiable)\n- overlaps_by_day: object with keys MON, TUE, WED, THU, FRI each an integer from 0 to 1440\n- max_overlap_check: true | false (self-check that max_overlap_minutes equals the maximum listed overlap)",
+  "$comment": "Entropy remains bounded by schema ranges and enums."
+}


### PR DESCRIPTION
## Summary

- Copies 11 `vault_result_*` schema files from vcav repo into VFC `schemas/`
- Adds all 11 to verifier-core's compile-time embed manifest (`build.rs` + `schema_validator.rs`)
- Updates `test_schema_count` assertion from 5 → 16
- Updates module doc comment to reflect vault result schemas are now embedded

The offline verifier (`verifier-cli` without `--schema-dir`) can now validate receipts that use vault result schemas without requiring an external schema directory.

Closes vcav-io/vault-family-core#8

## How to verify

```bash
cargo test -p verifier-core
```

All 77 tests pass.

## Test plan

- [x] `test_schema_count` asserts 16 embedded schemas
- [x] `test_all_embedded_schemas_are_valid_json` validates all 16 parse as JSON
- [x] Full `cargo test -p verifier-core` passes (77 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)