### PR TITLE
spike: verifier-wasm Node.js loading (#747)

### DIFF
--- a/packages/verifier-wasm/SPIKE-RESULTS.md
+++ b/packages/verifier-wasm/SPIKE-RESULTS.md
@@ -1,0 +1,129 @@
+# Spike Results: verifier-wasm in Node.js
+
+**Issue:** vcav-io/vcav#747
+**Date:** 2026-02-28
+**Branch:** `claude/747-wasm-node`
+
+## Summary
+
+The `verifier-wasm` crate **works correctly in Node.js** using `wasm-pack build --target nodejs`. All
+five exported WASM functions (`init`, `verify_receipt`, `verify_with_artefacts`, `verify_with_manifest`,
+`verify_bundle`, `version`) load and execute correctly. All three verification tiers (Tier 1 signature,
+Tier 2 artefact hashes, Tier 3 manifest) return correct results against the cross-language test vectors.
+Performance is well within acceptance criteria.
+
+## Build
+
+### Target used: `--target nodejs`
+
+```bash
+# Requires rustup Rust (not Homebrew Rust) in PATH
+PATH="$HOME/.rustup/toolchains/1.88.0-aarch64-apple-darwin/bin:$PATH" \
+  wasm-pack build packages/verifier-wasm --target nodejs --release --out-dir pkg-node
+```
+
+Output is in `packages/verifier-wasm/pkg-node/`:
+- `verifier_wasm.js` — CommonJS module (`require()`-compatible)
+- `verifier_wasm_bg.wasm` — ~760 KB compiled WASM binary
+- `verifier_wasm.d.ts` / `verifier_wasm_bg.wasm.d.ts` — TypeScript type definitions
+- `package.json` — `"main": "verifier_wasm.js"`, no `"type": "module"` (CJS)
+
+### Why not `--target web`?
+
+The `--target web` output uses ES module syntax (`import.meta`, `export`) and requires
+`fetch` or a manual `WebAssembly.instantiateStreaming` call to initialise the WASM binary.
+This is awkward in Node.js without ESM shims. The `--target nodejs` output uses CommonJS
+`require()` and synchronously initialises the binary with `fs.readFileSync`, making it
+trivially loadable in any Node.js version without additional setup.
+
+### PATH issue with Homebrew Rust
+
+On this machine, `wasm-pack` picked up Homebrew `rustc` (1.93.0) instead of rustup's
+`rustc` (1.88.0) when run without explicit PATH manipulation. This is because
+`/opt/homebrew/bin` appears before `~/.rustup/toolchains/.../bin` in the default shell
+`PATH`. The Homebrew Rust does not have the `wasm32-unknown-unknown` target installed, so
+wasm-pack failed with:
+
+> `wasm32-unknown-unknown target not found in sysroot: /opt/homebrew/Cellar/rust/1.93.0`
+
+**Fix:** Ensure `~/.cargo/bin` or the rustup toolchain bin directory is first in PATH, or
+invoke via `rustup run <toolchain> wasm-pack build …`.
+
+## Compatibility Notes
+
+The `Cargo.toml` already has the correct dependency configuration for cross-target builds:
+
+```toml
+getrandom = { version = "0.2", features = ["js"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+```
+
+The `wasm-opt = false` metadata flag (also in `Cargo.toml`) ensures portability across
+Binaryen versions.
+
+## Test Results
+
+19 / 19 tests passed (`packages/verifier-wasm/test-node-loading.js`):
+
+| Test | Result |
+|------|--------|
+| Tier 1 positive: `verify_receipt` → `ok: true` | PASS |
+| Tier 1 negative: `verify_receipt` → `ok: false` with error | PASS |
+| Tier 2 positive: `verify_with_artefacts` → `ok: true` | PASS |
+| Tier 3 positive: `verify_with_manifest` → `ok: true`, all fields | PASS (6 assertions) |
+| Tier 3 negative: `verify_with_manifest` strict_runtime=false → `ok: true`, `runtime_hash_match: false` | PASS (3 assertions) |
+| `verify_bundle` tier 3 full bundle → `ok: true`, `tier: 3` | PASS (2 assertions) |
+| `version()` returns non-empty string | PASS |
+
+`cargo test -p verifier-wasm`: `ok. 0 passed; 0 failed` (no native tests defined; the
+wasm-bindgen tests require a browser harness).
+
+## Benchmark Results
+
+Measured on Apple M-series (aarch64), Node.js v22, 10 iterations each
+(`packages/verifier-wasm/benchmark-node.js`):
+
+| Metric | Value | Criterion | Result |
+|--------|-------|-----------|--------|
+| Cold WASM module load | **2.1 ms** | < 500 ms | PASS |
+| Memory overhead (RSS delta) | **2.1 MB** | < 50 MB | PASS |
+| `verify_receipt` p50 | **0.53 ms** | — | — |
+| `verify_receipt` p95 | **5.2 ms** | — | — |
+| `verify_with_manifest` p50 | **0.74 ms** | — | — |
+| `verify_with_manifest` p95 | **2.9 ms** | — | — |
+| `verify_bundle` p50 | **0.55 ms** | — | — |
+| `verify_bundle` p95 | **3.4 ms** | — | — |
+
+The high p95 values (~3–5 ms) relative to p50 (~0.5–0.7 ms) are expected for the first
+few iterations on a warm JIT — they settle quickly. In practice, a long-lived Node.js
+process would stay close to the p50 numbers.
+
+## Recommendations for Production Use
+
+1. **Use `--target nodejs` for all server-side builds.** The generated CJS module is a
+   straightforward `require()` drop-in. No `fetch`, no ESM shims, no async initialisation.
+
+2. **Fix the PATH / rustup issue in CI.** Add an explicit `rustup override set` or
+   `RUSTUP_TOOLCHAIN` env var, or ensure `~/.cargo/bin` is first in `PATH` in the
+   build environment.
+
+3. **Pre-warm the WASM module at process startup**, not at first verification call.
+   `require()` is synchronous and takes ~2 ms — negligible at startup, but avoidable
+   latency if deferred.
+
+4. **The WASM binary is ~760 KB uncompressed.** For production deployment (e.g., inside
+   the MCP server or vcav-orchestrator), bundle it as an asset and load with
+   `path.resolve(__dirname, 'verifier_wasm_bg.wasm')`. The current `pkg-node` directory
+   can be published to an npm registry or vendored directly into the consuming package.
+
+5. **No need for the subprocess / CLI fallback.** The direct WASM loading works cleanly.
+   The CLI fallback (`vcav verify`) is still useful as a user-facing tool, but is
+   unnecessary overhead in programmatic server contexts.
+
+6. **TypeScript integration:** The generated `.d.ts` files are complete. Import with:
+   ```typescript
+   import * as verifier from './pkg-node/verifier_wasm';
+   const result = JSON.parse(verifier.verify_receipt(receiptJson, pubkeyHex));
+   ```

--- a/packages/verifier-wasm/benchmark-node.js
+++ b/packages/verifier-wasm/benchmark-node.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Benchmark: verifier-wasm cold load time, verify latency, and memory overhead.
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const pkgDir = path.resolve(__dirname, 'pkg-node');
+const vectorDir = path.resolve(__dirname, '../../data/test-vectors');
+
+function loadVector(name) {
+  return JSON.parse(fs.readFileSync(path.join(vectorDir, name), 'utf8'));
+}
+
+function rssBytes() {
+  return process.memoryUsage().rss;
+}
+
+function formatMs(ns) {
+  return (ns / 1e6).toFixed(3) + ' ms';
+}
+
+function percentile(sorted, p) {
+  const idx = Math.ceil(sorted.length * p / 100) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cold load: module require() + WASM init
+// ---------------------------------------------------------------------------
+
+const rssBefore = rssBytes();
+const loadStart = process.hrtime.bigint();
+const wasm = require(pkgDir);
+const loadEnd = process.hrtime.bigint();
+const rssAfter = rssBytes();
+
+const coldLoadMs = Number(loadEnd - loadStart) / 1e6;
+const memoryOverheadMb = (rssAfter - rssBefore) / (1024 * 1024);
+
+console.log('=== Cold load ===');
+console.log(`  Load time:        ${coldLoadMs.toFixed(3)} ms`);
+console.log(`  Memory overhead:  ${memoryOverheadMb.toFixed(2)} MB  (RSS before: ${(rssBefore / 1024 / 1024).toFixed(1)} MB, after: ${(rssAfter / 1024 / 1024).toFixed(1)} MB)`);
+console.log(`  Criteria <500 ms: ${coldLoadMs < 500 ? 'PASS' : 'FAIL'}`);
+console.log(`  Criteria <50 MB:  ${memoryOverheadMb < 50 ? 'PASS' : 'FAIL'}`);
+
+// ---------------------------------------------------------------------------
+// 2. Verify latency — 10 iterations each tier
+// ---------------------------------------------------------------------------
+
+const ITERS = 10;
+
+const t1v = loadVector('verification_tier1_positive_01.json');
+const t1receipt = JSON.stringify(t1v.input.receipt);
+const t1pubkey = t1v.input.public_key_hex;
+
+const t3v = loadVector('verification_tier3_positive_01.json');
+const t3receipt = JSON.stringify(t3v.input.receipt);
+const t3pubkey = t3v.input.public_key_hex;
+const t3manifest = JSON.stringify(t3v.input.manifest);
+const t3bundle = JSON.stringify({
+  manifest: t3v.input.manifest,
+  profile: t3v.input.profile,
+  policy: t3v.input.policy,
+});
+
+function benchmarkFn(label, fn) {
+  const times = [];
+  for (let i = 0; i < ITERS; i++) {
+    const t0 = process.hrtime.bigint();
+    fn();
+    const t1 = process.hrtime.bigint();
+    times.push(Number(t1 - t0) / 1e6);
+  }
+  times.sort((a, b) => a - b);
+  const p50 = percentile(times, 50);
+  const p95 = percentile(times, 95);
+  const min = times[0];
+  const max = times[times.length - 1];
+  console.log(`\n  ${label}`);
+  console.log(`    p50: ${p50.toFixed(3)} ms  p95: ${p95.toFixed(3)} ms  min: ${min.toFixed(3)} ms  max: ${max.toFixed(3)} ms`);
+  return { p50, p95, min, max };
+}
+
+console.log('\n=== Verify latency (10 iterations each) ===');
+
+const r1 = benchmarkFn('verify_receipt (Tier 1)', () => {
+  wasm.verify_receipt(t1receipt, t1pubkey);
+});
+
+const r3 = benchmarkFn('verify_with_manifest (Tier 3)', () => {
+  wasm.verify_with_manifest(t3receipt, t3pubkey, t3manifest, false);
+});
+
+const rb = benchmarkFn('verify_bundle (Tier 3 full)', () => {
+  wasm.verify_bundle(t3receipt, t3pubkey, t3bundle, false);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Summary
+// ---------------------------------------------------------------------------
+
+console.log('\n=== Summary ===');
+console.log(`  Cold load:              ${coldLoadMs.toFixed(3)} ms  (criteria: <500 ms) — ${coldLoadMs < 500 ? 'PASS' : 'FAIL'}`);
+console.log(`  Memory overhead:        ${memoryOverheadMb.toFixed(2)} MB  (criteria: <50 MB) — ${memoryOverheadMb < 50 ? 'PASS' : 'FAIL'}`);
+console.log(`  verify_receipt p50:     ${r1.p50.toFixed(3)} ms`);
+console.log(`  verify_with_manifest p50: ${r3.p50.toFixed(3)} ms`);
+console.log(`  verify_bundle p50:      ${rb.p50.toFixed(3)} ms`);

--- a/packages/verifier-wasm/test-node-loading.js
+++ b/packages/verifier-wasm/test-node-loading.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Spike test: load verifier-wasm in Node.js and run verification tiers.
+// Uses fixtures from data/test-vectors/.
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+// ---------------------------------------------------------------------------
+// Load WASM module
+// ---------------------------------------------------------------------------
+
+const pkgDir = path.resolve(__dirname, 'pkg-node');
+const wasm = require(pkgDir);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadVector(name) {
+  const p = path.resolve(__dirname, '../../data/test-vectors', name);
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(label, condition, detail) {
+  if (condition) {
+    console.log(`  PASS  ${label}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${label}${detail ? ': ' + detail : ''}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1: verify_receipt
+// ---------------------------------------------------------------------------
+
+console.log('\n=== Tier 1: verify_receipt ===');
+{
+  const v = loadVector('verification_tier1_positive_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+
+  const result = JSON.parse(wasm.verify_receipt(receipt, pubkey));
+  assert('tier1 positive: ok === true', result.ok === true, JSON.stringify(result));
+  assert('tier1 positive: no error field', !result.error, result.error);
+}
+
+{
+  const v = loadVector('verification_tier1_negative_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+
+  const result = JSON.parse(wasm.verify_receipt(receipt, pubkey));
+  assert('tier1 negative: ok === false', result.ok === false, JSON.stringify(result));
+  assert('tier1 negative: error field present', typeof result.error === 'string', JSON.stringify(result));
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: verify_with_artefacts
+// ---------------------------------------------------------------------------
+
+console.log('\n=== Tier 2: verify_with_artefacts ===');
+{
+  const v = loadVector('verification_tier2_positive_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+  const profile = JSON.stringify(v.input.profile);
+  const policy = JSON.stringify(v.input.policy);
+
+  const result = JSON.parse(wasm.verify_with_artefacts(receipt, pubkey, profile, policy));
+  assert('tier2 positive: ok === true', result.ok === true, JSON.stringify(result));
+  assert('tier2 positive: no error field', !result.error, result.error);
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3: verify_with_manifest
+// ---------------------------------------------------------------------------
+
+console.log('\n=== Tier 3: verify_with_manifest ===');
+{
+  const v = loadVector('verification_tier3_positive_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+  const manifest = JSON.stringify(v.input.manifest);
+
+  const result = JSON.parse(wasm.verify_with_manifest(receipt, pubkey, manifest, false));
+  assert('tier3 positive: ok === true', result.ok === true, JSON.stringify(result));
+  assert('tier3 positive: signature_valid', result.signature_valid === true, JSON.stringify(result));
+  assert('tier3 positive: profile_covered', result.profile_covered === true, JSON.stringify(result));
+  assert('tier3 positive: policy_covered', result.policy_covered === true, JSON.stringify(result));
+  assert('tier3 positive: runtime_hash_match', result.runtime_hash_match === true, JSON.stringify(result));
+  assert('tier3 positive: guardian_hash_match', result.guardian_hash_match === true, JSON.stringify(result));
+}
+
+{
+  // Tier 3 "negative" fixture: wrong runtime hash, but strict_runtime=false means it still passes.
+  // The expected outcome is ok=true but runtime_hash_match=false.
+  const v = loadVector('verification_tier3_negative_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+  const manifest = JSON.stringify(v.input.manifest);
+  const strictRuntime = v.input.strict_runtime !== undefined ? v.input.strict_runtime : false;
+
+  const result = JSON.parse(wasm.verify_with_manifest(receipt, pubkey, manifest, strictRuntime));
+  // strict_runtime=false: passes overall but reports runtime mismatch
+  assert('tier3 negative: ok === true (strict_runtime=false)', result.ok === true, JSON.stringify(result));
+  assert('tier3 negative: runtime_hash_match === false', result.runtime_hash_match === false, JSON.stringify(result));
+  assert('tier3 negative: signature_valid', result.signature_valid === true, JSON.stringify(result));
+}
+
+// ---------------------------------------------------------------------------
+// verify_bundle (full bundle convenience function)
+// ---------------------------------------------------------------------------
+
+console.log('\n=== verify_bundle (tier 3 full bundle) ===');
+{
+  const v = loadVector('verification_tier3_positive_01.json');
+  const receipt = JSON.stringify(v.input.receipt);
+  const pubkey = v.input.public_key_hex;
+  const bundle = JSON.stringify({
+    manifest: v.input.manifest,
+    profile: v.input.profile,
+    policy: v.input.policy,
+  });
+
+  const result = JSON.parse(wasm.verify_bundle(receipt, pubkey, bundle, false));
+  assert('verify_bundle tier3: ok === true', result.ok === true, JSON.stringify(result));
+  assert('verify_bundle tier3: tier === 3', result.tier === 3, JSON.stringify(result));
+}
+
+// ---------------------------------------------------------------------------
+// version()
+// ---------------------------------------------------------------------------
+
+console.log('\n=== version() ===');
+{
+  const v = wasm.version();
+  assert('version returns string', typeof v === 'string', v);
+  assert('version non-empty', v.length > 0, v);
+  console.log(`  version: ${v}`);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Spike for vcav-io/vcav#747: confirm `verifier-wasm` works in Node.js.

- **Build target:** `--target nodejs` (CommonJS output, synchronous `require()`)
- **All 19 tests pass** across Tier 1, 2, and 3 verification using cross-language test vectors
- **Performance well within criteria:** 2 ms cold load, 2 MB RSS overhead, <1 ms p50 verify latency

## Files added

| File | Purpose |
|------|---------|
| `packages/verifier-wasm/test-node-loading.js` | Loads the WASM module, runs all 3 tiers against fixtures |
| `packages/verifier-wasm/benchmark-node.js` | Cold load, p50/p95 latency, RSS delta |
| `packages/verifier-wasm/SPIKE-RESULTS.md` | Full findings, build notes, production recommendations |

## Benchmark results (Apple M-series, Node.js v22)

| Metric | Value | Criterion |
|--------|-------|-----------|
| Cold load | 2.1 ms | < 500 ms ✅ |
| Memory overhead | 2.1 MB | < 50 MB ✅ |
| `verify_receipt` p50 | 0.53 ms | — |
| `verify_with_manifest` p50 | 0.74 ms | — |
| `verify_bundle` p50 | 0.55 ms | — |

## How to verify

```bash
# Build (requires rustup Rust in PATH, not Homebrew)
PATH="$HOME/.rustup/toolchains/1.88.0-aarch64-apple-darwin/bin:$PATH" \
  wasm-pack build packages/verifier-wasm --target nodejs --release --out-dir pkg-node

# Run tests (all 19 should pass)
node packages/verifier-wasm/test-node-loading.js

# Run benchmarks
node packages/verifier-wasm/benchmark-node.js

# Native cargo tests
cargo test -p verifier-wasm
```

Closes vcav-io/vcav#747