### PR TITLE
feat(receipt-v2): session status, execution lane, channel capacity claims

### DIFF
--- a/packages/receipt-core/src/lib.rs
+++ b/packages/receipt-core/src/lib.rs
@@ -57,6 +57,13 @@ pub use manifest::{
     ArtefactEntry, ManifestArtefacts, PublicationManifest, RuntimeHashes, UnsignedManifest,
     MANIFEST_DOMAIN_PREFIX,
 };
+pub use receipt_v2::{
+    AssuranceLevel, BudgetEnforcementMode, BudgetUsageV2, Claims, Commitments, ExecutionLaneV2,
+    HashAlgorithm, InputCommitment, Operator, PreflightBundle, ProviderAttestation,
+    ReceiptSignature, ReceiptV2, SessionStatus, SignatureAlgorithm, SignatureV2, TeeAttestation,
+    TeeType, TokenUsage, UnsignedReceiptV2, CANONICALIZATION_V2,
+    CHANNEL_CAPACITY_MEASUREMENT_VERSION, DOMAIN_PREFIX_V2, SCHEMA_VERSION_V2,
+};
 pub use signer::{
     compute_budget_chain_id, compute_receipt_hash, compute_receipt_key_id,
     create_handoff_signing_message, create_signing_message, create_signing_message_v2,
@@ -64,13 +71,6 @@ pub use signer::{
     sign_and_assemble_receipt_v2, sign_handoff, sign_receipt, sign_receipt_v2, verify_handoff,
     verify_receipt, verify_receipt_v2, SigningError, BUDGET_CHAIN_DOMAIN_PREFIX, DOMAIN_PREFIX,
     RECEIPT_HASH_DOMAIN_PREFIX, RECEIPT_HASH_PLACEHOLDER, SESSION_HANDOFF_DOMAIN_PREFIX,
-};
-pub use receipt_v2::{
-    AssuranceLevel, BudgetEnforcementMode, BudgetUsageV2, Claims, Commitments, ExecutionLaneV2,
-    HashAlgorithm, InputCommitment, Operator, PreflightBundle, ProviderAttestation,
-    ReceiptSignature, ReceiptV2, SessionStatus, SignatureAlgorithm, SignatureV2, TeeAttestation,
-    TeeType, TokenUsage, UnsignedReceiptV2, CANONICALIZATION_V2,
-    CHANNEL_CAPACITY_MEASUREMENT_VERSION, DOMAIN_PREFIX_V2, SCHEMA_VERSION_V2,
 };
 pub use vault_family_types::{ExecutionLane, LaneId};
 

--- a/packages/receipt-core/src/receipt_v2.rs
+++ b/packages/receipt-core/src/receipt_v2.rs
@@ -286,7 +286,6 @@ pub struct Claims {
     pub relay_software_version: Option<String>,
 
     // --- Session outcome (issue #189) ---
-
     /// Session outcome status.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<SessionStatus>,
@@ -296,13 +295,11 @@ pub struct Claims {
     pub signal_class: Option<String>,
 
     // --- Execution lane (issue #190) ---
-
     /// Execution environment: `standard` or `tee`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution_lane: Option<ExecutionLaneV2>,
 
     // --- Channel capacity (issue #188) ---
-
     /// Schema's structural channel capacity in bits — log2 of the number of
     /// distinct outputs the schema permits. Deterministically derivable from
     /// the committed schema hash.
@@ -821,10 +818,7 @@ mod tests {
         tampered.commitments.contract_hash = "0".repeat(64);
 
         let result = verify_receipt_v2(&tampered, &signature, &verifying_key);
-        assert!(
-            result.is_err(),
-            "tampered commitment must not verify"
-        );
+        assert!(result.is_err(), "tampered commitment must not verify");
     }
 
     #[test]
@@ -846,71 +840,70 @@ mod tests {
         // We verify that v1 verify_receipt rejects a v2-signed payload with
         // a different domain prefix — this is tested indirectly via sign+verify v1.
         // The key assertion: signing with different domain prefixes produces different bytes.
-        let msg_v1 =
-            crate::signer::create_signing_message(&{
-                // Minimal v1 receipt
-                use crate::receipt::{BudgetUsageRecord, ReceiptStatus, SCHEMA_VERSION};
-                use vault_family_types::{BudgetTier, ExecutionLane, Purpose};
-                use chrono::TimeZone;
-                UnsignedReceipt {
-                    schema_version: SCHEMA_VERSION.to_string(),
-                    session_id: "a".repeat(64),
-                    purpose_code: Purpose::Compatibility,
-                    participant_ids: vec![],
-                    runtime_hash: "b".repeat(64),
-                    guardian_policy_hash: "c".repeat(64),
-                    model_weights_hash: "d".repeat(64),
-                    llama_cpp_version: "0.1.0".to_string(),
-                    inference_config_hash: "e".repeat(64),
-                    output_schema_version: "1.0.0".to_string(),
-                    session_start: Utc.with_ymd_and_hms(2026, 3, 4, 0, 0, 0).unwrap(),
-                    session_end: Utc.with_ymd_and_hms(2026, 3, 4, 0, 1, 0).unwrap(),
-                    fixed_window_duration_seconds: 60,
-                    status: ReceiptStatus::Completed,
-                    execution_lane: ExecutionLane::SoftwareLocal,
-                    output: None,
-                    output_entropy_bits: 0,
-                    receipt_payload_type: None,
-                    receipt_payload_version: None,
-                    payload: None,
-                    mitigations_applied: vec![],
-                    budget_usage: BudgetUsageRecord {
-                        pair_id: "f".repeat(64),
-                        window_start: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
-                        bits_used_before: 0,
-                        bits_used_after: 0,
-                        budget_limit: 128,
-                        budget_tier: BudgetTier::Default,
-                        budget_enforcement: None,
-                        compartment_id: None,
-                    },
-                    budget_chain: None,
-                    model_identity: None,
-                    agreement_hash: None,
-                    model_profile_hash: None,
-                    policy_bundle_hash: None,
-                    contract_hash: None,
-                    output_schema_id: None,
-                    output_schema_hash: None,
-                    signal_class: None,
-                    entropy_budget_bits: None,
-                    schema_entropy_ceiling_bits: None,
-                    prompt_template_hash: None,
-                    contract_timing_class: None,
-                    ifc_output_label: None,
-                    ifc_policy_hash: None,
-                    ifc_label_receipt: None,
-                    ifc_joined_confidentiality: None,
-                    entropy_status_commitment: None,
-                    ledger_head_hash: None,
-                    delta_commitment_counterparty: None,
-                    delta_commitment_contract: None,
-                    policy_declaration: None,
-                    receipt_key_id: None,
-                    attestation: None,
-                }
-            })
-            .unwrap();
+        let msg_v1 = crate::signer::create_signing_message(&{
+            // Minimal v1 receipt
+            use crate::receipt::{BudgetUsageRecord, ReceiptStatus, SCHEMA_VERSION};
+            use chrono::TimeZone;
+            use vault_family_types::{BudgetTier, ExecutionLane, Purpose};
+            UnsignedReceipt {
+                schema_version: SCHEMA_VERSION.to_string(),
+                session_id: "a".repeat(64),
+                purpose_code: Purpose::Compatibility,
+                participant_ids: vec![],
+                runtime_hash: "b".repeat(64),
+                guardian_policy_hash: "c".repeat(64),
+                model_weights_hash: "d".repeat(64),
+                llama_cpp_version: "0.1.0".to_string(),
+                inference_config_hash: "e".repeat(64),
+                output_schema_version: "1.0.0".to_string(),
+                session_start: Utc.with_ymd_and_hms(2026, 3, 4, 0, 0, 0).unwrap(),
+                session_end: Utc.with_ymd_and_hms(2026, 3, 4, 0, 1, 0).unwrap(),
+                fixed_window_duration_seconds: 60,
+                status: ReceiptStatus::Completed,
+                execution_lane: ExecutionLane::SoftwareLocal,
+                output: None,
+                output_entropy_bits: 0,
+                receipt_payload_type: None,
+                receipt_payload_version: None,
+                payload: None,
+                mitigations_applied: vec![],
+                budget_usage: BudgetUsageRecord {
+                    pair_id: "f".repeat(64),
+                    window_start: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+                    bits_used_before: 0,
+                    bits_used_after: 0,
+                    budget_limit: 128,
+                    budget_tier: BudgetTier::Default,
+                    budget_enforcement: None,
+                    compartment_id: None,
+                },
+                budget_chain: None,
+                model_identity: None,
+                agreement_hash: None,
+                model_profile_hash: None,
+                policy_bundle_hash: None,
+                contract_hash: None,
+                output_schema_id: None,
+                output_schema_hash: None,
+                signal_class: None,
+                entropy_budget_bits: None,
+                schema_entropy_ceiling_bits: None,
+                prompt_template_hash: None,
+                contract_timing_class: None,
+                ifc_output_label: None,
+                ifc_policy_hash: None,
+                ifc_label_receipt: None,
+                ifc_joined_confidentiality: None,
+                entropy_status_commitment: None,
+                ledger_head_hash: None,
+                delta_commitment_counterparty: None,
+                delta_commitment_contract: None,
+                policy_declaration: None,
+                receipt_key_id: None,
+                attestation: None,
+            }
+        })
+        .unwrap();
         let msg_v2 = crate::signer::create_signing_message_v2(&unsigned_v2).unwrap();
 
         // Domain prefix bytes differ → signing messages differ → signatures differ

--- a/packages/vault-family-types/src/contract.rs
+++ b/packages/vault-family-types/src/contract.rs
@@ -67,7 +67,6 @@ pub struct Contract {
     pub model_profile_id: Option<String>,
 
     // --- NEW v2 fields ---
-
     /// Content hash of the enforcement policy governing this session (#147).
     /// If present, the receipt's guardian_policy_hash MUST match.
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Restores load-bearing protocol fields dropped in the v1→v2 transition. All fields are optional Claims with `skip_serializing_if`, so existing v2 receipts remain valid.

- **Session status** (#189): `SessionStatus` enum (`success`/`rejected`/`aborted`/`error`) + `signal_class` string — enables failure receipts
- **Execution lane** (#190): `ExecutionLaneV2` enum (`standard`/`tee`) — asserts execution environment, forward-compatible with TEE support
- **Channel capacity** (#188): `channel_capacity_bits_upper_bound`, `channel_capacity_measurement_version` (`enum_cardinality_v1`), `entropy_budget_bits`, `schema_entropy_ceiling_bits`, `BudgetUsageV2` struct — restores schema capacity measurement reporting

Schema version bumped from 2.0.0 → 2.1.0.

## Test plan

- [x] All 271 receipt-core tests pass including 7 new tests
- [x] Full workspace builds cleanly
- [ ] AV relay integration (separate PR, depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)