### PR TITLE
feat: relay key pinning + failure receipt fields

### DIFF
--- a/packages/receipt-core/src/receipt_v2.rs
+++ b/packages/receipt-core/src/receipt_v2.rs
@@ -161,6 +161,14 @@ pub struct Commitments {
     /// URI from which the preflight bundle can be fetched.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preflight_bundle_uri: Option<String>,
+
+    /// SHA-256(JCS(rejected_output)) for failure receipts where inference
+    /// produced output that was subsequently rejected (schema validation,
+    /// policy gate). `None` for success receipts and pre-inference failures.
+    /// Separate from `output_hash` to preserve the invariant that `output_hash`
+    /// is always the hash of a valid, accepted output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejected_output_hash: Option<String>,
 }
 
 // ============================================================================
@@ -495,6 +503,7 @@ mod tests {
                 output_retrieval_uri: None,
                 output_media_type: None,
                 preflight_bundle_uri: None,
+                rejected_output_hash: None,
             },
             claims: Claims {
                 model_identity_asserted: Some("gpt-4o-2024-11-20".to_string()),
@@ -761,6 +770,7 @@ mod tests {
                 output_retrieval_uri: None,
                 output_media_type: None,
                 preflight_bundle_uri: None,
+                rejected_output_hash: None,
             },
             claims: Claims {
                 model_identity_asserted: None,

--- a/packages/vault-family-types/src/contract.rs
+++ b/packages/vault-family-types/src/contract.rs
@@ -97,6 +97,15 @@ pub struct Contract {
     /// Entropy enforcement mode (#151 gap 6).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entropy_enforcement: Option<EntropyEnforcementMode>,
+
+    /// Ed25519 verifying key (lowercase hex, 64 chars) of the relay that should
+    /// execute this session. If present, the relay MUST verify its own key matches
+    /// before proceeding. Key rotation invalidates contracts that pin the old key.
+    ///
+    /// Future direction: may evolve to `required_signers: Vec<SignerIdentity>` to
+    /// support TEE dual-signing (enclave key + operator key).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_verifying_key_hex: Option<String>,
 }
 
 #[cfg(test)]
@@ -122,6 +131,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         };
         let json = serde_json::to_string(&contract).unwrap();
         let parsed: Contract = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary
- Adds `relay_verifying_key_hex: Option<String>` to `Contract` for relay key pinning (pre-TEE)
- Adds `rejected_output_hash: Option<String>` to `Commitments` for failure receipts (separate from `output_hash` to preserve success invariant)

Both fields are `Option` with `serde(default, skip_serializing_if)` — fully backward compatible.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] AV rev bump after merge (blocked on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)