### PR TITLE
feat(receipt-v2): add user_data_hex to TeeAttestation

### DIFF
--- a/packages/receipt-core/src/receipt_v2.rs
+++ b/packages/receipt-core/src/receipt_v2.rs
@@ -424,6 +424,11 @@ pub struct TeeAttestation {
     /// this field without independent verification.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transcript_hash_hex: Option<String>,
+    /// Platform user_data field from the attestation report (hex).
+    /// For SEV-SNP this is the 64 bytes bound to the quote via REPORT_DATA.
+    /// Verifiers recompute the transcript hash and check it matches this field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_data_hex: Option<String>,
 }
 
 // ============================================================================
@@ -696,6 +701,7 @@ mod tests {
             attestation_hash: Some("b".repeat(64)),
             receipt_signing_pubkey_hex: Some("c".repeat(64)),
             transcript_hash_hex: Some("d".repeat(128)),
+            user_data_hex: Some("e".repeat(128)),
         };
         let json = serde_json::to_string(&att).unwrap();
         let parsed: TeeAttestation = serde_json::from_str(&json).unwrap();
@@ -711,6 +717,7 @@ mod tests {
             attestation_hash: None,
             receipt_signing_pubkey_hex: None,
             transcript_hash_hex: None,
+            user_data_hex: None,
         };
         let json = serde_json::to_string(&att).unwrap();
         assert!(!json.contains("attestation_hash"));


### PR DESCRIPTION
## Summary
- Adds `user_data_hex: Option<String>` to `TeeAttestation` struct
- For SEV-SNP: the 64-byte platform user_data bound via REPORT_DATA (hex-encoded)
- Enables tee-verifier to check `user_data == recomputed_transcript_hash` without quote parsing
- All existing tests updated and passing (593 tests)

## Context
Prerequisite for av-tee tee-verifier crate (Phase 2). Without this field, verifiers would need platform-specific quote parsing to extract user_data.

## Test plan
- [x] All 593 VFC tests pass
- [x] Clippy clean, fmt clean
- [x] Backwards-compatible (field is `Option`, `skip_serializing_if = "Option::is_none"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)